### PR TITLE
Adding a variable to force to use a specific subnet with Openstack

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -411,6 +411,17 @@ Otherwise, Terraform can find it automatically.
 
 **Post Build Modification Effect**: rebuild of all instances at next `terraform apply`.
 
+#### 5.1.4 os_int_subnet (optional)
+
+**default value**: None
+
+Defines the name of the internal subnet on which the instances are
+connected. Define this only if you have more than one subnet defined in your
+OpenStack network. Otherwise, Terraform can find it automatically.
+Can be use to force a v4 subnet when both v4 and v6 exist.
+
+**Post Build Modification Effect**: rebuild of all instances at next `terraform apply`.
+
 ### 5.2 Google Cloud
 
 #### 5.2.1 project_name

--- a/docs/README.md
+++ b/docs/README.md
@@ -418,7 +418,7 @@ Otherwise, Terraform can find it automatically.
 Defines the name of the internal subnet on which the instances are
 connected. Define this only if you have more than one subnet defined in your
 OpenStack network. Otherwise, Terraform can find it automatically.
-Can be use to force a v4 subnet when both v4 and v6 exist.
+Can be used to force a v4 subnet when both v4 and v6 exist.
 
 **Post Build Modification Effect**: rebuild of all instances at next `terraform apply`.
 

--- a/openstack/network.tf
+++ b/openstack/network.tf
@@ -9,6 +9,7 @@ data "openstack_networking_network_v2" "int_network" {
 }
 
 data "openstack_networking_subnet_v2" "subnet" {
+  name       = var.os_int_subnet
   network_id = data.openstack_networking_network_v2.int_network.id
 }
 

--- a/openstack/openstack.tf
+++ b/openstack/openstack.tf
@@ -12,3 +12,8 @@ variable "os_int_network" {
   type    = string
   default = null
 }
+
+variable "os_int_subnet" {
+  type    = string
+  default = null
+}


### PR DESCRIPTION
This is required on Openstack when multiple subnets are in the same network. Mostly when both IPv4 and IPv6 is available. 