### PR TITLE
Made sudo users a list

### DIFF
--- a/aws/infrastructure.tf
+++ b/aws/infrastructure.tf
@@ -119,7 +119,7 @@ resource "aws_security_group" "allow_any_inside_vpc" {
 
 resource "aws_key_pair" "key" {
   key_name   = "${var.cluster_name}-key"
-  public_key = var.public_keys[0]
+  public_key = var.sudo_users[0]["public_keys"][0]
 }
 
 resource "aws_network_interface" "mgmt" {

--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -177,7 +177,7 @@ resource "azurerm_linux_virtual_machine" "login" {
 
   disable_password_authentication = true
   dynamic "admin_ssh_key" {
-    for_each = var.public_keys
+    for_each = var.sudo_users[0]["public_keys"]
     iterator = key
     content {
       username = "azure"
@@ -221,7 +221,7 @@ resource "azurerm_linux_virtual_machine" "mgmt" {
   
   disable_password_authentication = true
   dynamic "admin_ssh_key" {
-    for_each = var.public_keys
+    for_each = var.sudo_users[0]["public_keys"]
     iterator = key
     content {
       username = "azure"
@@ -302,7 +302,7 @@ locals {
           managed_disk_type = var.managed_disk_type
           root_disk_size    = var.root_disk_size,
           user_data         = data.template_cloudinit_config.node_config[key].rendered,
-          public_keys       = var.public_keys,
+          public_keys       = var.sudo_users[0]["public_keys"],
         },
         local.node[key]
     )

--- a/cloud-init/mgmt.yaml
+++ b/cloud-init/mgmt.yaml
@@ -5,18 +5,22 @@ packages:
   - unzip
 
 users:
-  - name: ${sudoer_username}
+%{ for user in sudo_users ~}
+  - name: ${user.username}
     groups: adm, wheel, systemd-journal
-    homedir: /${sudoer_username}
+    homedir: /${user.username}
     selinux_user: unconfined_u
     sudo: ALL=(ALL) NOPASSWD:ALL
     ssh_authorized_keys:
-%{ for key in ssh_authorized_keys ~}
+%{ for key in user.public_keys ~}
       - ${key}
+%{ endfor ~}
 %{ endfor ~}
 
 runcmd:
-  - restorecon -R /${sudoer_username}
+%{ for user in sudo_users ~}
+  - restorecon -R /${user.username}
+%{ endfor ~}
   - "(echo -e '\nHostKeyAlgorithms ssh-rsa\n' >> /etc/ssh/sshd_config && systemctl restart sshd)"
   - yum remove -y firewalld
   - yum upgrade -y

--- a/cloud-init/puppet.yaml
+++ b/cloud-init/puppet.yaml
@@ -5,18 +5,22 @@ packages:
   - unzip
 
 users:
-  - name: ${sudoer_username}
+%{ for user in sudo_users ~}
+  - name: ${user.username}
     groups: adm, wheel, systemd-journal
-    homedir: /${sudoer_username}
+    homedir: /${user.username}
     selinux_user: unconfined_u
     sudo: ALL=(ALL) NOPASSWD:ALL
     ssh_authorized_keys:
-%{ for key in ssh_authorized_keys ~}
+%{ for key in user.public_keys ~}
       - ${key}
+%{ endfor ~}
 %{ endfor ~}
 
 runcmd:
-  - restorecon -R /${sudoer_username}
+%{ for user in sudo_users ~}
+  - restorecon -R /${user.username}
+%{ endfor ~}
   - "(echo -e '\nHostKeyAlgorithms ssh-rsa\n' >> /etc/ssh/sshd_config && systemctl restart sshd)"
   - yum upgrade -y
   - yum -y install https://yum.puppet.com/puppet6-release-el-$(grep -oP 'VERSION_ID="\K[^"]+' /etc/os-release).noarch.rpm

--- a/common/data.tf
+++ b/common/data.tf
@@ -50,7 +50,7 @@ data "template_file" "hieradata" {
   template = data.http.hieradata_template.body
 
   vars = {
-    sudoer_username = var.sudoer_username
+    sudoer_username = var.sudo_users[0]["username"]
     freeipa_passwd  = random_string.freeipa_passwd.result
     cluster_name    = var.cluster_name
     domain_name     = local.domain_name
@@ -78,8 +78,7 @@ data "template_cloudinit_config" "mgmt_config" {
         hieradata             = data.template_file.hieradata.rendered,
         user_hieradata        = var.hieradata,
         node_name             = format("mgmt%d", count.index + 1),
-        sudoer_username       = var.sudoer_username,
-        ssh_authorized_keys   = var.public_keys,
+        sudo_users            = var.sudo_users,
         home_dev              = local.home_dev,
         project_dev           = local.project_dev,
         scratch_dev           = local.scratch_dev,
@@ -119,8 +118,7 @@ EOF
       "${path.module}/cloud-init/puppet.yaml",
       {
         node_name             = format("login%d", count.index + 1),
-        sudoer_username       = var.sudoer_username,
-        ssh_authorized_keys   = var.public_keys,
+        sudo_users            = var.sudo_users,
         puppetmaster          = local.mgmt1_ip,
         puppetmaster_password = random_string.puppetmaster_password.result,
       }
@@ -138,8 +136,7 @@ data "template_cloudinit_config" "node_config" {
       "${path.module}/cloud-init/puppet.yaml",
       {
         node_name             = each.key,
-        sudoer_username       = var.sudoer_username,
-        ssh_authorized_keys   = var.public_keys,
+        sudo_users            = var.sudo_users,
         puppetmaster          = local.mgmt1_ip,
         puppetmaster_password = random_string.puppetmaster_password.result,
       }

--- a/common/outputs.tf
+++ b/common/outputs.tf
@@ -10,8 +10,8 @@ output "domain" {
   value = "${lower(var.domain)}"
 }
 
-output "sudoer_username" {
-  value = var.sudoer_username
+output "sudo_users" {
+  value = var.sudo_users
 }
 
 output "freeipa_passwd" {

--- a/common/variables.tf
+++ b/common/variables.tf
@@ -32,7 +32,15 @@ variable "storage" {
 variable "domain" {
 }
 
-variable "public_keys" {
+variable "sudo_users" {
+  type = list( object({
+    username=string,
+    public_keys=list(string)
+  }))
+  default=[{
+    username="centos"
+    public_keys=[""]
+  }]
 }
 
 variable "guest_passwd" {
@@ -50,10 +58,6 @@ variable "puppetenv_rev" {
 variable hieradata {
   type = string
   default = ""
-}
-
-variable "sudoer_username" {
-  default = "centos"
 }
 
 variable "firewall_rules" {

--- a/examples/openstack/main.tf
+++ b/examples/openstack/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 module "openstack" {
-  source = "git::https://github.com/ComputeCanada/magic_castle.git//openstack"
+  source = "./openstack"
 
   cluster_name = "phoenix"
   domain       = "calculquebec.cloud"
@@ -25,7 +25,9 @@ module "openstack" {
     scratch_size = 50
   }
 
-  public_keys = [file("~/.ssh/id_rsa.pub")]
+  sudo_users=[
+    {username="centos",public_keys=[""]},
+    ]
 
   # Shared password, randomly chosen if blank
   guest_passwd = ""
@@ -34,8 +36,8 @@ module "openstack" {
   os_floating_ips = []
 }
 
-output "sudoer_username" {
-  value = module.openstack.sudoer_username
+output "sudoer_usernames" {
+  value = [for user in module.openstack.sudo_users : user["username"]]
 }
 
 output "guest_usernames" {

--- a/openstack/infrastructure.tf
+++ b/openstack/infrastructure.tf
@@ -56,7 +56,7 @@ resource "openstack_compute_secgroup_v2" "secgroup_1" {
 
 resource "openstack_compute_keypair_v2" "keypair" {
   name       = "${var.cluster_name}-key"
-  public_key = var.public_keys[0]
+  public_key = var.sudo_users[0]["public_keys"][0]
 }
 
 resource "openstack_blockstorage_volume_v2" "home" {


### PR DESCRIPTION
I modified the main.tf to allow for a list of sudo users each with a list of public keys.

I have only tested it with the "OpenStack" provider. Most of the changes are in "common" and "cloud-init" folders which are provider independent I believe. The one exception is the "openstack/infrastructure.tf" file to get an openstack keypair. I am not sure how relevent that is however, as I would image that the cloud-init settings for users/keypairs would override that. I did go through the other provider infractucture.tf files and made changes were nessacary but I haven't tested it for those other providers.

Additionally I changed the "openstack" module source to point to the local "./openstack" folder as I needed it to use my local changes otherwise it would use the repo and fail. This could likely be changed back to the git repo once it is merged.