### PR TITLE
bumped minimum requirement of terraform due to the use of function 

### DIFF
--- a/examples/aws/main.tf
+++ b/examples/aws/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.21"
 }
 
 module "aws" {

--- a/examples/azure/main.tf
+++ b/examples/azure/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.21"
 }
 
 module "azure" {

--- a/examples/gcp/main.tf
+++ b/examples/gcp/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.21"
 }
 
 module "gcp" {

--- a/examples/openstack/main.tf
+++ b/examples/openstack/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.21"
 }
 
 module "openstack" {

--- a/examples/ovh/main.tf
+++ b/examples/ovh/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.21"
 }
 
 module "ovh" {


### PR DESCRIPTION
setsubtract, introduced in terraform 0.12.21

Otherwise, the following error is observed : 
```
Error: Call to unknown function
  on openstack/data.tf line 12, in locals:
  12:             for key in setsubtract(keys(node), ["prefix", "count"]):
There is no function named "setsubtract".
``` 