### PR TITLE
Fixed a few typos and indentation errors in documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -84,9 +84,9 @@ This command will ask for a password, enter your OpenStack password.
 
 1. Open a terminal
 2. Verify Terraform was properly installed by looking at the version
-```
-$ terraform version
-```
+    ```
+    $ terraform version
+    ```
 
 ## 2. Cloud Cluster Architecture Overview
 
@@ -179,9 +179,9 @@ Valid format is a series of labels 1-63 characters long matching the
 regular expression `[a-z]([-a-z0-9]*[a-z0-9])`, concatenated with periods.
 - No wildcard record A of the form `*.domain. IN A x.x.x.x` exists for that
 domain. You can verify no such record exist with `dig`:
-```
-dig +short '*.${domain}'
-```
+    ```
+    dig +short '*.${domain}'
+    ```
 
 **Post Build Modification Effect**: rebuild of all instances at next `terraform apply`.
 
@@ -755,20 +755,20 @@ password of the user accounts, follow these steps:
 2. Create a variable containing the randomly generated password: `OLD_PASSWD=<random_passwd>`
 3. Create a variable containing the new human defined password: `NEW_PASSWD=<human_passwd>`.
 This password must respect the FreeIPA password policy. To display the policy enter
-```
-# Enter FreeIPA admin password available in /etc/puppetlabs/code/environments/production/data/terraform_data.yaml
-$ kinit admin
-$ ipa pwpolicy-show
-$ kdestroy
-```
+    ```
+    # Enter FreeIPA admin password available in /etc/puppetlabs/code/environments/production/data/terraform_data.yaml
+    $ kinit admin
+    $ ipa pwpolicy-show
+    $ kdestroy
+    ```
 4. Loop on all user accounts to replace the old password by the new one:
-```
-for username in $(ls /home/ | grep user); do
-  echo -e "$OLD_PASSWD" | kinit $username
-  echo -e "$NEW_PASSWD\n$NEW_PASSWD" | ipa user-mod $username --password
-  kdestroy
-done
-```
+    ```
+    for username in $(ls /home/ | grep user); do
+      echo -e "$OLD_PASSWD" | kinit $username
+      echo -e "$NEW_PASSWD\n$NEW_PASSWD" | ipa user-mod $username --password
+      kdestroy
+    done
+    ```
 
 ### 10.3 Add a User Account
 
@@ -796,9 +796,9 @@ to increase the number of guest accounts after creating the cluster with Terrafo
 can modify the hieradata file of the Puppet environment.
 
 1. On `mgmt1` and with `sudo`, open the file
-```
-/etc/puppetlabs/code/environments/production/data/terraform_data.yaml
-```
+    ```
+    /etc/puppetlabs/code/environments/production/data/terraform_data.yaml
+    ```
 2. Increase the number associated with the field `profile::freeipa::guest_accounts::nb_accounts:`
 to the number of guest accounts you want.
 3. Save the file.

--- a/docs/README.md
+++ b/docs/README.md
@@ -297,7 +297,7 @@ Requirements:
 
 #### 4.6.3 node
 
-The value associated with the `login` key is required to be a list of
+The value associated with the `node` key is required to be a list of
 map with at least two keys: `type` and `count`.
 
 If the list contains more than one map, at least one of the map will need
@@ -352,7 +352,7 @@ count and type variables can be modified at any point of your cluster lifetime.
 Terraform will manage the creation or destruction of the virtual machines
 for you.
 
-Modifying any of these variables after the cluster is built will only affects
+Modifying any of these variables after the cluster is built will only affect
 the type of instances associated with the variables at next `terraform apply`.
 
 ### 4.7 Storage: type, home_size, project_size, scratch_size
@@ -520,7 +520,7 @@ If your domain DNS records are managed by one of the supported providers,
 follow the instructions in the corresponding sections to have the DNS records and SSL
 certificates managed by Magic Castle.
 
-If you DNS providers is not supported, you can manually create the DNS records and
+If your DNS providers is not supported, you can manually create the DNS records and
 generate the SSL certificates. Refer to the last subsection for more details.
 
 **Requirement**: A private key associated with one of the
@@ -569,8 +569,8 @@ and the SSL certificates manually.
 
 #### 6.3.1 DNS Records
 
-The DNS records registerd by Magic Castle are listed in
-[dns/record_generator/main.tf](https://github.com/ComputeCanada/magic_castle/blob/master/dns/record_generator/main.tf). All records point to the one of login nodes.
+The DNS records registered by Magic Castle are listed in
+[dns/record_generator/main.tf](https://github.com/ComputeCanada/magic_castle/blob/master/dns/record_generator/main.tf). All records point to one of the login nodes.
 
 These are the records that need to be created in your DNS provider.
 
@@ -695,7 +695,7 @@ the count value of the instance type you wish to destroy to 0.
 ### 9.2 Reset
 
 On some occasions, it is desirable to rebuild some of the instances from scratch.
-Using `terraform taint`, you can designate ressources that will be rebuild at
+Using `terraform taint`, you can designate resources that will be rebuilt at
 next application of the plan.
 
 To rebuild the first login node :
@@ -726,10 +726,10 @@ Replace `centos` by the value of `sudoer_username` if it is
 different.
 3. SSH in the management node : `ssh mgmt1`
 
-**note on Google Cloud**: In GCP, [OS Login](https://cloud.google.com/compute/docs/instances/managing-instance-access)
+**Note on Google Cloud**: In GCP, [OS Login](https://cloud.google.com/compute/docs/instances/managing-instance-access)
 lets you use Compute Engine IAM roles to manage SSH access to Linux instances.
 This feature is incompatible with Magic Castle. Therefore, it is turned off in
-the instances metadata (`os_login="FALSE`). The only account with admin rights
+the instances metadata (`enable-oslogin="FALSE"`). The only account with admin rights
 that can log in the cluster is configured by the variable `sudoer_username`
 (default: `centos`).
 
@@ -858,7 +858,7 @@ Refer to [Magic Castle Globus Endpoint documentation](globus.md).
 
 The modifications of some of the parameters in the `main.tf` file can trigger the
 rebuild of the `mgmt1` instance. This instance hosts the Puppet Server on which
-depends the Puppet agent of the other instances. When `mgmt1` is rebuild, the other
+depends the Puppet agent of the other instances. When `mgmt1` is rebuilt, the other
 Puppet agents cease to recognize Puppet Server identity since the Puppet Server
 identity and certificates have been regenerated.
 

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -58,16 +58,16 @@ release files will be built for all providers currently supported by Magic Castl
 Examples:
 
 - Building a release for OpenStack with the puppet repo master branch:
-```
-$ ./release.sh master openstack
-```
+    ```
+    $ ./release.sh master openstack
+    ```
 - Building a release for GCP with the latest Terraform and cloud-init, and version 5.8 of puppet
 Magic Castle:
-``` 
-$ ./release.sh 5.8 gcp
-```
+    ``` 
+    $ ./release.sh 5.8 gcp
+    ```
 - Building a release for Azure and OVH with the latest Terraform and cloud-init, and version 5.7 of puppet
 Magic Castle:
-```
-$ ./release.sh 5.7 azure ovh
-```
+    ```
+    $ ./release.sh 5.7 azure ovh
+    ```

--- a/docs/globus.md
+++ b/docs/globus.md
@@ -24,25 +24,25 @@ submodule, you are on your own.
 On `mgmt1`:
 1. Open the file `/etc/puppetlabs/code/environments/production/data/common.yaml` with sudo rights
 and add the following lines:
-```
-profile::globus::base::globus_user: your_globus_username
-profile::globus::base::globus_password: your_globus_password
-```
+    ```
+    profile::globus::base::globus_user: your_globus_username
+    profile::globus::base::globus_password: your_globus_password
+    ```
 Replace `your_globus_username` and `your_globus_password` by their respective value.
 
 On `login1`:
 1. Restart puppet : `sudo systemctl restart puppet`.
 2. Give Puppet a few minutes to setup Globus. You can confirm that
 everything was setup correctly by looking at the tail of the puppet log:
-```
-sudo journalctl -u puppet -f
-```
+    ```
+    sudo journalctl -u puppet -f
+    ```
 3. If everything is correct, `globus-gridftp-server` and `myproxy-server`
 services should be active. To confirm:
-```
-sudo systemctl status globus-gridftp-server
-sudo systemctl status myproxy-server
-```
+    ```
+    sudo systemctl status globus-gridftp-server
+    sudo systemctl status myproxy-server
+    ```
 4. If both services are active, in a browser, go to
 https://app.globus.org/endpoints?scope=administered-by-me
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/35122940/81182852-5865ba80-8f7c-11ea-9f5c-432c269718ef.png)

PyCharm seems to struggle when displaying non-indented code blocks within a numbered list. This seems to be fixed when adding 4 spaces at the beginning of each code block in the list. This problem does not arise when displaying the Markdown documentation on GitHub though.
I also fixed a few typos.