### PR TITLE
Changed root_disk_size from 10GB to 20GB for GCP

### DIFF
--- a/examples/gcp/main.tf
+++ b/examples/gcp/main.tf
@@ -19,6 +19,10 @@ module "gcp" {
     ]
   }
 
+  # Magic Castle's default root disk size is 10GB.
+  # GCP requires at least 20GB of root disk.
+  root_disk_size = 20
+
   storage = {
     type         = "nfs"
     home_size    = 100


### PR DESCRIPTION
If unchanged root_disk_size of 10GB causes this error:

```
Error: Error creating instance: googleapi: Error 400: Invalid value for field 'resource.disks[0].initializeParams.diskSizeGb': '10'. Requested disk size cannot be smaller than the image size (20 GB), invalid

  on gcp/infrastructure.tf line 86, in resource "google_compute_instance" "mgmt":
  86: resource "google_compute_instance" "mgmt" {
```