### PR TITLE
Upload hieradata yaml files with Terraform file provisioner

### DIFF
--- a/aws/infrastructure.tf
+++ b/aws/infrastructure.tf
@@ -324,6 +324,7 @@ resource "aws_instance" "node" {
 locals {
   mgmt1_ip        = aws_network_interface.mgmt[0].private_ip
   puppetmaster_ip = aws_network_interface.mgmt[0].private_ip
+  puppetmaster_id = aws_instance.mgmt[0].id
   public_ip       = aws_eip.login[*].public_ip
   login_ids       = aws_instance.login[*].id
   cidr            = aws_subnet.private_subnet.cidr_block

--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -363,6 +363,7 @@ locals {
   resource_group_name = var.azure_resource_group == "" ? azurerm_resource_group.group[0].name : var.azure_resource_group
   mgmt1_ip        = azurerm_network_interface.mgmtNIC[0].private_ip_address
   puppetmaster_ip = azurerm_network_interface.mgmtNIC[0].private_ip_address
+  puppetmaster_id = azurerm_linux_virtual_machine.mgmt[0].id
   public_ip       = azurerm_public_ip.loginIP[*].ip_address
   login_ids       = azurerm_linux_virtual_machine.login[*].id
   cidr            = "10.0.1.0/24"

--- a/cloud-init/puppetmaster.yaml
+++ b/cloud-init/puppetmaster.yaml
@@ -43,8 +43,10 @@ runcmd:
   - rm -rf /etc/puppetlabs/code/environments/production
   - git clone ${puppetenv_git} /etc/puppetlabs/code/environments/production
   - "(cd /etc/puppetlabs/code/environments/production; git checkout ${puppetenv_rev})"
-  - mv /etc/puppetlabs/code/data/terraform_data.yaml /etc/puppetlabs/code/environments/production/data/
-  - mv /etc/puppetlabs/code/data/user_data.yaml /etc/puppetlabs/code/environments/production/data/
+  - mkdir -p /etc/puppetlabs/data
+  - chgrp -R puppet /etc/puppetlabs/data
+  - ln -sf /etc/puppetlabs/data/terraform_data.yaml /etc/puppetlabs/code/environments/production/data/
+  - ln -sf /etc/puppetlabs/data/user_data.yaml /etc/puppetlabs/code/environments/production/data/
   - /opt/puppetlabs/puppet/bin/gem install librarian-puppet
   - "(cd /etc/puppetlabs/code/environments/production/ && HOME=/root PATH=$PATH:/opt/puppetlabs/puppet/bin /opt/puppetlabs/puppet/bin/librarian-puppet install)"
 # Bootstrap services that are essential to puppet agents
@@ -57,12 +59,6 @@ runcmd:
   - for i in /etc/sysconfig/network-scripts/ifcfg-*; do if ! ip link show | grep -q "$${i##*-}:"; then rm -f $i; fi; done
 
 write_files:
-  - content: |
-      ${ indent(6, hieradata) }
-    path: /etc/puppetlabs/code/data/terraform_data.yaml
-  - content: |
-      ${ indent(6, user_hieradata) }
-    path: /etc/puppetlabs/code/data/user_data.yaml
   - content: |
       127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4 puppet
     path: /etc/hosts

--- a/common/data.tf
+++ b/common/data.tf
@@ -78,8 +78,6 @@ data "template_cloudinit_config" "mgmt_config" {
         puppetenv_rev         = var.puppetenv_rev,
         puppetmaster_ip       = local.puppetmaster_ip,
         puppetmaster_password = random_string.puppetmaster_password.result,
-        hieradata             = data.template_file.hieradata.rendered,
-        user_hieradata        = var.hieradata,
         node_name             = format("mgmt%d", count.index + 1),
         sudoer_username       = var.sudoer_username,
         ssh_authorized_keys   = var.public_keys,

--- a/common/data.tf
+++ b/common/data.tf
@@ -146,3 +146,39 @@ data "template_cloudinit_config" "node_config" {
     )
   }
 }
+
+resource "null_resource" "deploy_hieradata" {
+
+  connection {
+    type         = "ssh"
+    bastion_host = local.public_ip[0]
+    bastion_user = var.sudoer_username
+    user         = var.sudoer_username
+    host         = local.puppetmaster_ip
+  }
+
+  triggers = {
+    user_data    = md5(var.hieradata)
+    hieradata    = md5(data.template_file.hieradata.rendered)
+    puppetmaster = local.puppetmaster_id
+  }
+
+  provisioner "file" {
+    content     = data.template_file.hieradata.rendered
+    destination = "terraform_data.yaml"
+  }
+
+  provisioner "file" {
+    content     = var.hieradata
+    destination = "user_data.yaml"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mkdir -p /etc/puppetlabs/data",
+      "sudo install -m 650 terraform_data.yaml user_data.yaml /etc/puppetlabs/data/",
+      "sudo chgrp puppet /etc/puppetlabs/data/terraform_data.yaml /etc/puppetlabs/data/user_data.yaml &> /dev/null || true",
+      "rm -f terraform_data.yaml user_data.yaml"
+    ]
+  }
+}

--- a/common/variables.tf
+++ b/common/variables.tf
@@ -68,7 +68,7 @@ variable "puppetenv_rev" {
 
 variable hieradata {
   type        = string
-  default     = ""
+  default     = "---"
   description = "String formatted as YAML defining hiera key-value pairs to be included in the puppet environment"
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -267,8 +267,10 @@ section [10.3](#103-add-a-user-account) and [10.4](#104-increase-the-number-of-g
 
 **Requirement**: Must be an integer, minimum value is 0.
 
-**Post Build Modification Effect**: rebuild `mgmt1` instance at next `terraform apply`
-([see section 10.8](#108-recovering-from-mgmt1-rebuild)).
+**Post Build Modification Effect**: trigger scp of hieradata files at next `terraform apply`.
+If `nb_users` is increased, new guest accounts will be created during the following
+puppet run on `mgmt1`. If `nb_users` is decreased, it will have no effect: the guest accounts
+already created will be left intact.
 
 ### 4.6 instances
 
@@ -283,17 +285,14 @@ with 2 keys: `type` and `count`.
 
 Number of management instances to create.
 
-**Warning**: All other type of instances depend on the existence of at
-least one management node named `mgmt1`. While it is possible to have
-to 0 management vm and login or node count greater than 0, the cluster
-will not be functional.
+**Minimum**: 1
 
 ##### type
 
 Cloud provider name for the combination of CPU, RAM and other features
 on which will run the management instances.
 
-Requirements:
+**Requirements:**
 - CPUs: 2 cores
 - RAM: 6GB
 
@@ -306,12 +305,14 @@ with 2 keys: `type` and `count`.
 
 Number of login instances to create.
 
+**Minimum**: 1
+
 ##### type
 
 Cloud provider name for the combination of CPU, RAM and other features
 on which will run the login instances.
 
-Requirements:
+**Requirements:**
 - CPUs: 2 cores
 - RAM: 2GB
 
@@ -327,12 +328,14 @@ to define a value for the key `prefix`.
 
 Number of compute node instances to create.
 
+**Minimum**: 0
+
 ##### type
 
 Cloud provider name for the combination of CPU, RAM and other features
 on which will run the compute node instances.
 
-Requirements:
+**Requirements:**
 - CPUs: 1 core
 - RAM: 2GB
 
@@ -435,8 +438,12 @@ randomly generated one.
 
 **Requirement**: Minimum length **8 characters**.
 
-**Post Build Modification Effect**: rebuild `mgmt1` instance at next `terraform apply`
-([see section 10.8](#108-recovering-from-mgmt1-rebuild)).
+**Post Build Modification Effect**: trigger scp of hieradata files at next `terraform apply`.
+Password of already created guest accounts will not be changed. Guest accounts created after
+the password change will have this password.
+
+To modify the password of previously created guest accounts, refer to section
+([see section 10.2](#102-replace-the-user-account-password)).
 
 ### 4.10 root_disk_size (optional)
 
@@ -484,14 +491,14 @@ Refer to the following Puppet modules' documentation to know more about the key-
 - [puppet-jupyterhub](https://github.com/ComputeCanada/puppet-jupyterhub/blob/master/README.md#hieradata-configuration)
 
 
+The file created from this string can be found on `mgmt1` as
+```
+/etc/puppetlabs/data/user_data.yaml
+```
+
 **Requirement**: The string needs to respect the [YAML syntax](https://en.wikipedia.org/wiki/YAML#Syntax).
 
-**Post Build Modification Effect**: rebuild `mgmt1` instance at next `terraform apply`
-([see section 10.8](#108-recovering-from-mgmt1-rebuild)). To modify the hieradata once the cluster is built,
-prefer modifying the file created from this string. The file can be found on `mgmt1` as
-```
-/etc/puppetlabs/code/environments/production/data/user_data.yaml
-```
+**Post Build Modification Effect**: trigger scp of hieradata files at next `terraform apply`.
 
 ### 4.13 firewall_rules (optional)
 

--- a/gcp/infrastructure.tf
+++ b/gcp/infrastructure.tf
@@ -295,6 +295,7 @@ resource "google_compute_firewall" "default" {
 locals {
   mgmt1_ip        = google_compute_address.mgmt[0].address
   puppetmaster_ip = google_compute_address.mgmt[0].address
+  puppetmaster_id = google_compute_instance.mgmt[0].id
   public_ip       = google_compute_address.static[*].address
   login_ids       = google_compute_instance.login[*].id
   home_dev        = [for vol in google_compute_disk.home:    "/dev/disk/by-id/google-${vol.name}"]

--- a/openstack/infrastructure.tf
+++ b/openstack/infrastructure.tf
@@ -271,6 +271,7 @@ resource "openstack_compute_instance_v2" "node" {
 locals {
   mgmt1_ip        = openstack_networking_port_v2.port_mgmt[0].all_fixed_ips[0]
   puppetmaster_ip = openstack_networking_port_v2.port_mgmt[0].all_fixed_ips[0]
+  puppetmaster_id = openstack_compute_instance_v2.mgmt[0].id
   login_ids       = openstack_compute_instance_v2.login[*].id
   home_dev        = [for vol in openstack_blockstorage_volume_v2.home:    "/dev/disk/by-id/*${substr(vol.id, 0, 20)}"]
   project_dev     = [for vol in openstack_blockstorage_volume_v2.project: "/dev/disk/by-id/*${substr(vol.id, 0, 20)}"]


### PR DESCRIPTION
This allows modifications of the number of guest accounts, the guest account password and the hieradata string without requiring a rebuild of mgmt1.