### PR TITLE
Use AWS private SSH key in example

### DIFF
--- a/examples/aws/main.tf
+++ b/examples/aws/main.tf
@@ -72,7 +72,7 @@ output "public_ip" {
 #   public_ip        = module.aws.ip
 #   login_ids        = module.aws.login_ids
 #   rsa_public_key   = module.aws.rsa_public_key
-#   ssh_private_key  = module.openstack.ssh_private_key
+#   ssh_private_key  = module.aws.ssh_private_key
 #   sudoer_username  = module.aws.sudoer_username
 # }
 


### PR DESCRIPTION
The AWS example should use the AWS private SSH key, not the OpenStack one