### PR TITLE
Fixed puppet hieradata documentation typo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -547,7 +547,7 @@ List of useful examples:
 - Receive logs of Puppet runs with changes to your email, add the
 following line to the string:
     ```
-    profile::base::email: "me@example.org"
+    profile::base::admin_email: "me@example.org"
     ```
 - Define ip addresses that can never be banned by fail2ban:
     ```


### PR DESCRIPTION
The name of the configuration variable `profile::base::email` doesn't match with the one documented here: https://github.com/ComputeCanada/puppet-magic_castle/#profilebase (`profile::base::admin_email`).

_1 virtual beer has been added to lefreud's account._