### PR TITLE
Notify about what the freeipa admin username is

### DIFF
--- a/common/outputs.tf
+++ b/common/outputs.tf
@@ -14,6 +14,10 @@ output "sudoer_username" {
   value = var.sudoer_username
 }
 
+output "freeipa_username" {
+  value = "admin"
+}
+
 output "freeipa_passwd" {
   value = random_string.freeipa_passwd.result
 }

--- a/examples/aws/main.tf
+++ b/examples/aws/main.tf
@@ -78,6 +78,14 @@ output "public_ip" {
 #   sudoer_username  = module.aws.sudoer_username
 # }
 
+# output "freeipa_username" {
+#   value = module.aws.freeipa_username
+# }
+
+# output "freeipa_passwd" {
+#   value = module.aws.freeipa_passwd
+# }
+
 # output "hostnames" {
 # 	value = module.dns.hostnames
 # }

--- a/examples/azure/main.tf
+++ b/examples/azure/main.tf
@@ -87,6 +87,13 @@ output "public_ip" {
 #   sudoer_username  = module.azure.sudoer_username
 # }
 
+# output "freeipa_username" {
+#   value = module.azure.freeipa_username
+# }
+
+# output "freeipa_passwd" {
+#   value = module.azure.freeipa_passwd
+# }
 
 # output "hostnames" {
 # 	value = module.dns.hostnames

--- a/examples/gcp/main.tf
+++ b/examples/gcp/main.tf
@@ -85,6 +85,14 @@ output "public_ip" {
 #   sudoer_username  = module.gcp.sudoer_username
 # }
 
+# output "freeipa_username" {
+#   value = module.gcp.freeipa_username
+# }
+
+# output "freeipa_passwd" {
+#   value = module.gcp.freeipa_passwd
+# }
+
 # output "hostnames" {
 # 	value = module.dns.hostnames
 # }

--- a/examples/openstack/main.tf
+++ b/examples/openstack/main.tf
@@ -80,6 +80,14 @@ output "public_ip" {
 #   sudoer_username  = module.openstack.sudoer_username
 # }
 
+# output "freeipa_username" {
+#   value = module.openstack.freeipa_username
+# }
+
+# output "freeipa_passwd" {
+#   value = module.openstack.freeipa_passwd
+# }
+
 # output "hostnames" {
 #   value = module.dns.hostnames
 # }

--- a/examples/ovh/main.tf
+++ b/examples/ovh/main.tf
@@ -78,6 +78,14 @@ output "public_ip" {
 #   sudoer_username  = module.ovh.sudoer_username
 # }
 
+# output "freeipa_username" {
+#   value = module.ovh.freeipa_username
+# }
+
+# output "freeipa_passwd" {
+#   value = module.ovh.freeipa_passwd
+# }
+
 # output "hostnames" {
 # 	value = module.dns.hostnames
 # }


### PR DESCRIPTION
It wasn't clear to me that the administrator username for freeipa is not `sudoer_username` but `"admin"` and took me a while to figure out when I first tried.