### PR TITLE
Add SSH public keys to terraform_data and ignore changes to user_data for instances.

### DIFF
--- a/aws/infrastructure.tf
+++ b/aws/infrastructure.tf
@@ -31,11 +31,12 @@ module "cluster_config" {
   cloud_provider  = local.cloud_provider
   cloud_region    = local.cloud_region
   sudoer_username = var.sudoer_username
+  public_keys     = var.public_keys
   guest_passwd    = var.guest_passwd
   domain_name     = module.design.domain_name
   cluster_name    = var.cluster_name
   volume_devices  = local.volume_devices
-  private_ssh_key = module.instance_config.private_key
+  tf_ssh_key      = module.instance_config.ssh_key
 }
 
 data "aws_availability_zones" "available" {
@@ -95,7 +96,8 @@ resource "aws_instance" "instances" {
 
   lifecycle {
     ignore_changes = [
-      ami
+      ami,
+      user_data,
     ]
   }
 

--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -31,11 +31,12 @@ module "cluster_config" {
   cloud_provider  = local.cloud_provider
   cloud_region    = local.cloud_region
   sudoer_username = var.sudoer_username
+  public_keys     = var.public_keys
   guest_passwd    = var.guest_passwd
   domain_name     = module.design.domain_name
   cluster_name    = var.cluster_name
   volume_devices  = local.volume_devices
-  private_ssh_key = module.instance_config.private_key
+  tf_ssh_key      = module.instance_config.ssh_key
 }
 
 # Check if user provided resource group is valid
@@ -102,7 +103,8 @@ resource "azurerm_linux_virtual_machine" "instances" {
   lifecycle {
     ignore_changes = [
       source_image_reference,
-      source_image_id
+      source_image_id,
+      custom_data,
     ]
   }
 }

--- a/common/cluster_config/main.tf
+++ b/common/cluster_config/main.tf
@@ -30,8 +30,9 @@ locals {
       instances = yamlencode(var.instances)
       tag_ip    = yamlencode(local.tag_ip)
       volumes   = yamlencode(var.volume_devices)
-      data = {
+      data      = yamlencode({
         sudoer_username = var.sudoer_username
+        public_keys     = var.tf_ssh_key.public == null ? var.public_keys : concat(var.public_keys, [var.tf_ssh_key.public])
         freeipa_passwd  = random_string.freeipa_passwd.result
         cluster_name    = lower(var.cluster_name)
         domain_name     = var.domain_name
@@ -39,7 +40,7 @@ locals {
         consul_token    = random_uuid.consul_token.result
         munge_key       = base64sha512(random_string.munge_key.result)
         nb_users        = var.nb_users
-      }
+      })
   })
   facts = {
     software_stack = var.software_stack
@@ -57,10 +58,10 @@ resource "null_resource" "deploy_hieradata" {
     type                = "ssh"
     bastion_host        = local.public_instances[keys(local.public_instances)[0]]["public_ip"]
     bastion_user        = var.sudoer_username
-    bastion_private_key = var.private_ssh_key
+    bastion_private_key = var.tf_ssh_key.private
     user                = var.sudoer_username
     host                = "puppet"
-    private_key         = var.private_ssh_key
+    private_key         = var.tf_ssh_key.private
   }
 
   triggers = {

--- a/common/cluster_config/terraform_data.yaml
+++ b/common/cluster_config/terraform_data.yaml
@@ -7,6 +7,4 @@ terraform:
   tag_ip:
     ${indent(4, tag_ip)}
   data:
-%{ for key, value in data ~}
-    ${key}: ${value}
-%{ endfor ~}
+    ${indent(4, data)}

--- a/common/cluster_config/variables.tf
+++ b/common/cluster_config/variables.tf
@@ -8,5 +8,6 @@ variable "nb_users" { }
 variable "software_stack" { }
 variable "cloud_provider" { }
 variable "cloud_region" { }
-variable "private_ssh_key" { }
+variable "tf_ssh_key" { }
 variable "hieradata" { }
+variable "public_keys" { }

--- a/common/instance_config/outputs.tf
+++ b/common/instance_config/outputs.tf
@@ -7,6 +7,6 @@ output "rsa_hostkeys" {
   value = { for x, values in var.instances : x => tls_private_key.rsa_hostkeys[values["prefix"]].public_key_openssh }
 }
 
-output "private_key" {
-  value = try(tls_private_key.ssh[0].private_key_pem, null)
+output "ssh_key" {
+  value = local.ssh_key
 }

--- a/common/outputs.tf
+++ b/common/outputs.tf
@@ -36,6 +36,6 @@ output "accounts" {
 }
 
 output "ssh_private_key" {
-  value     = module.instance_config.private_key
+  value     = module.instance_config.ssh_key.private
   sensitive = true
 }

--- a/gcp/infrastructure.tf
+++ b/gcp/infrastructure.tf
@@ -31,11 +31,12 @@ module "cluster_config" {
   cloud_provider  = local.cloud_provider
   cloud_region    = local.cloud_region
   sudoer_username = var.sudoer_username
+  public_keys     = var.public_keys
   guest_passwd    = var.guest_passwd
   domain_name     = module.design.domain_name
   cluster_name    = var.cluster_name
   volume_devices  = local.volume_devices
-  private_ssh_key = module.instance_config.private_key
+  tf_ssh_key      = module.instance_config.ssh_key
 }
 
 data "google_compute_zones" "available" {
@@ -111,7 +112,8 @@ resource "google_compute_instance" "instances" {
   lifecycle {
     ignore_changes = [
       attached_disk,
-      boot_disk[0].initialize_params[0].image
+      boot_disk[0].initialize_params[0].image,
+      metadata,
     ]
   }
 }

--- a/openstack/infrastructure.tf
+++ b/openstack/infrastructure.tf
@@ -26,11 +26,12 @@ module "cluster_config" {
   cloud_provider  = local.cloud_provider
   cloud_region    = local.cloud_region
   sudoer_username = var.sudoer_username
+  public_keys     = var.public_keys
   guest_passwd    = var.guest_passwd
   domain_name     = module.design.domain_name
   cluster_name    = var.cluster_name
   volume_devices  = local.volume_devices
-  private_ssh_key = module.instance_config.private_key
+  tf_ssh_key      = module.instance_config.ssh_key
 }
 
 data "openstack_images_image_v2" "image" {
@@ -55,6 +56,7 @@ resource "openstack_compute_instance_v2" "instances" {
   flavor_name = each.value.type
   key_pair    = openstack_compute_keypair_v2.keypair.name
   user_data   = base64gzip(module.instance_config.user_data[each.key])
+  metadata    = {}
 
   network {
     port = openstack_networking_port_v2.nic[each.key].id
@@ -84,6 +86,7 @@ resource "openstack_compute_instance_v2" "instances" {
     ignore_changes = [
       image_id,
       block_device[0].uuid,
+      user_data,
     ]
   }
 }


### PR DESCRIPTION
Address issue #174 where users who would like to add public ssh keys to the sudoer account have to destroy and re-create all instances, which is counter-intuitive and inefficient. 