### PR TITLE
Fix taint command example

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -991,7 +991,7 @@ next application of the plan.
 
 To rebuild the first login node :
 ```
-terraform taint 'module.openstack.openstack_compute_instance_v2.login[0]'
+terraform taint 'module.openstack.openstack_compute_instance_v2.instances["login1"]'
 terraform apply
 ```
 


### PR DESCRIPTION
The command
```
$ terraform taint 'module.openstack.openstack_compute_instance_v2.login[0]'
```

found in the documentation throws 

```
╷
│ Error: No such resource instance
│ 
│ There is no resource instance in the state with the address module.openstack.openstack_compute_instance_v2.login[0]. If the resource configuration has
│ just been added, you must run "terraform apply" once to create the corresponding instance(s) before they can be tainted.
╵
```
(Hope it qualifies for #33 :grin:)