### PR TITLE
Ensure AWS spot instances can be persistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Magic Castle
 
+<!-- markdown-link-check-disable-next-line -->
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4895357.svg)](https://doi.org/10.5281/zenodo.4895357)
 [![Build Status](https://github.com/ComputeCanada/magic_castle/actions/workflows/test.yaml/badge.svg)](https://github.com/ComputeCanada/magic_castle/actions/workflows/test.yaml)
 

--- a/aws/infrastructure.tf
+++ b/aws/infrastructure.tf
@@ -146,10 +146,11 @@ resource "aws_spot_instance_request" "spot_instances" {
   depends_on = [aws_internet_gateway.gw]
 
   # spot specific variables
-  wait_for_fulfillment   = lookup(each.value, "wait_for_fulfillment", true)
-  spot_type              = lookup(each.value, "spot_type", "persistent")
-  spot_price             = lookup(each.value, "spot_price", null)
-  block_duration_minutes = lookup(each.value, "block_duration_minutes", null)
+  wait_for_fulfillment           = lookup(each.value, "wait_for_fulfillment", true)
+  spot_type                      = lookup(each.value, "spot_type", "persistent")
+  instance_interruption_behavior = lookup(each.value, "instance_interruption_behavior", "stop")
+  spot_price                     = lookup(each.value, "spot_price", null)
+  block_duration_minutes         = lookup(each.value, "block_duration_minutes", null)
 
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -558,6 +558,7 @@ The following sections present the available attributes per provider.
 For instances with the `spot` tags, these attributes can also be set:
 - `wait_for_fulfillment` (default: true)
 - `spot_type` (default: permanent)
+- `instance_interruption_behavior` (default: stop)
 - `spot_price` (default: not set)
 - `block_duration_minutes` (default: not set) [note 1]
 For more information on these attributes, refer to


### PR DESCRIPTION
Our spot instances on Amazon are not actually persistent, when they die they do not restart. It was hard to discover but I found this documented somewhere:
 ```
* For <a>RunInstances</a>, persistent Spot Instance requests are only supported when
 * <b>InstanceInterruptionBehavior</b> is set to either <code>hibernate</code> or <code>stop</code>.
 * </p>
```
By default (and in our case) `InstanceInterruptionBehavior` is set to terminate , we need to change this to `stop`. I noticed as I left a spot cluster running over the weekend, and when I came back all the compute nodes had died.