### PR TITLE
Enable explictly port_security_enabled in network-2.tf for OpenStack

### DIFF
--- a/openstack/network-2.tf
+++ b/openstack/network-2.tf
@@ -35,10 +35,11 @@ resource "openstack_compute_secgroup_v2" "secgroup" {
 }
 
 resource "openstack_networking_port_v2" "nic" {
-  for_each           = module.design.instances
-  name               = format("%s-%s-port", var.cluster_name, each.key)
-  network_id         = local.network.id
-  security_group_ids = [openstack_compute_secgroup_v2.secgroup.id]
+  for_each              = module.design.instances
+  name                  = format("%s-%s-port", var.cluster_name, each.key)
+  network_id            = local.network.id
+  security_group_ids    = [openstack_compute_secgroup_v2.secgroup.id]
+  port_security_enabled = true
   fixed_ip {
     subnet_id = local.subnet.id
   }


### PR DESCRIPTION
OVH requires port security to be enabled, but does not enable it by default.