### PR TITLE
Allow openstack image to be a regular expression

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -465,6 +465,11 @@ Here is an example:
 }
 ```
 
+#### 4.6.3 OpenStack
+
+The image name can be a regular expression. If more than one image is returned by the query
+to OpenStack, the most recent is selected.
+
 ### 4.7 instances
 
 The `instances` variable is a map that defines the virtual machines that will form

--- a/examples/openstack/main.tf
+++ b/examples/openstack/main.tf
@@ -14,7 +14,7 @@ module "openstack" {
 
   cluster_name = "phoenix"
   domain       = "calculquebec.cloud"
-  image        = "Rocky-8.6-x64-2022-07"
+  image        = "Rocky-8"
 
   instances = {
     mgmt   = { type = "p4-6gb", tags = ["puppet", "mgmt", "nfs"], count = 1 }

--- a/openstack/infrastructure.tf
+++ b/openstack/infrastructure.tf
@@ -35,8 +35,9 @@ module "cluster_config" {
 }
 
 data "openstack_images_image_v2" "image" {
-  for_each = var.instances
-  name     = lookup(each.value, "image", var.image)
+  for_each    = var.instances
+  name_regex  = lookup(each.value, "image", var.image)
+  most_recent = true
 }
 
 data "openstack_compute_flavor_v2" "flavors" {

--- a/openstack/versions.tf
+++ b/openstack/versions.tf
@@ -4,6 +4,7 @@ terraform {
   required_providers {
     openstack = {
       source = "terraform-provider-openstack/openstack"
+      version = ">= 1.50.0"
     }
   }
 }


### PR DESCRIPTION
Fix the issue where the image name in OpenStack is a moving target and examples can fall behind.