### PR TITLE
Add `iptables-services` package by default

### DIFF
--- a/common/instance_config/puppet.yaml
+++ b/common/instance_config/puppet.yaml
@@ -29,7 +29,7 @@ runcmd:
       # Install required packages in runcmd instead of packages to speedup configuration
       # of the admin user. This reduces the risk of Terraform timing out when trying to
       # upload the terraform_data.yaml
-      yum -y install git pciutils unzip
+      yum -y install git pciutils unzip iptables-services
       yum remove -y firewalld --exclude=iptables
       # Upgrade all packages except Puppet if already installed
       yum -y upgrade -x puppet*


### PR DESCRIPTION
To avoid the error (seen on Rocky 8.8):
```
The service command supports only basic LSB actions (start, stop, restart, try-restart, reload, force-reload, status). For other actions, please try to use systemctl.
```

Proper fix is probably to switch to using `systemctl`, but this was a quick workaround