### PR TITLE
Allow redefinition of Puppetfile and skipping upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added `puppetservers` variable definition to `module.common.configuration`.
 
 ### Changed
-- Set `manage_etc_hosts` in cloud-init explictly to false.
+- Set `manage_etc_hosts` in cloud-init explicitly to false.
 - Fixed jq path to retrieve consul ACL agent token when launching the puppet event with consul.
 - Simplified provision remote-exec command by taking advantage puppet id and gid are reserved to "52".
 - Moved definition of autosign.log in cloud-init write_files

--- a/aws/infrastructure.tf
+++ b/aws/infrastructure.tf
@@ -28,6 +28,8 @@ module "configuration" {
   software_stack        = var.software_stack
   cloud_provider        = local.cloud_provider
   cloud_region          = local.cloud_region
+  skip_upgrade          = var.skip_upgrade
+  puppetfile            = var.puppetfile
 }
 
 module "provision" {

--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -28,6 +28,8 @@ module "configuration" {
   software_stack        = var.software_stack
   cloud_provider        = local.cloud_provider
   cloud_region          = local.cloud_region
+  skip_upgrade          = var.skip_upgrade
+  puppetfile            = var.puppetfile
 }
 
 module "provision" {

--- a/common/configuration/main.tf
+++ b/common/configuration/main.tf
@@ -98,6 +98,7 @@ locals {
       {
         tags                  = values.tags
         node_name             = key,
+        domain_name           = var.domain_name
         puppetenv_git         = var.config_git_url,
         puppetenv_rev         = var.config_version,
         puppetservers         = local.puppetservers,

--- a/common/configuration/main.tf
+++ b/common/configuration/main.tf
@@ -16,6 +16,9 @@ variable "guest_passwd" { }
 variable "generate_ssh_key" { }
 variable "public_keys" { }
 
+variable "skip_upgrade" { }
+variable "puppetfile" { }
+
 resource "tls_private_key" "ssh" {
   count     = var.generate_ssh_key ? 1 : 0
   algorithm = "ED25519"
@@ -107,6 +110,8 @@ locals {
         include_tf_data       = ! contains(local.all_tags, "public")
         terraform_data        = local.terraform_data
         terraform_facts       = local.terraform_facts
+        skip_upgrade          = var.skip_upgrade
+        puppetfile            = var.puppetfile
         hostkeys = {
           rsa = {
             private = tls_private_key.rsa[values.prefix].private_key_openssh

--- a/common/configuration/puppet.yaml
+++ b/common/configuration/puppet.yaml
@@ -31,8 +31,10 @@ runcmd:
       # upload the terraform_data.yaml
       yum -y install git pciutils unzip
       yum remove -y firewalld --exclude=iptables
+%{ if ! skip_upgrade ~}
       # Upgrade all packages except Puppet if already installed
       yum -y upgrade -x puppet*
+%{ endif ~}
       # Puppet agent configuration and install
       yum -y install https://yum.puppet.com/puppet7-release-el-$(grep -oP 'VERSION_ID="\K[^"]' /etc/os-release).noarch.rpm
       yum -y install puppet-agent-7.24.0
@@ -70,6 +72,14 @@ runcmd:
   - rm -rf /etc/puppetlabs/code/environments/production
   - git clone ${puppetenv_git} /etc/puppetlabs/code/environments/production
   - "(cd /etc/puppetlabs/code/environments/production; git checkout ${puppetenv_rev})"
+%{ if puppetfile != "" ~}
+%{ if strcontains(puppetfile, "forge") ~}
+  - cat /etc/puppetlabs/Puppetfile  > /etc/puppetlabs/code/environments/production/Puppetfile
+%{ else }
+  - cat /etc/puppetlabs/Puppetfile >> /etc/puppetlabs/code/environments/production/Puppetfile
+%{ endif ~}
+  - rm /etc/puppetlabs/Puppetfile
+%{ endif ~}
   - mkdir -p /etc/puppetlabs/data /etc/puppetlabs/facts
   - chgrp puppet /etc/puppetlabs/data /etc/puppetlabs/facts
   - ln -sf /etc/puppetlabs/data/terraform_data.yaml /etc/puppetlabs/code/environments/production/data/
@@ -138,6 +148,12 @@ write_files:
   - path: /etc/puppetlabs/facts/terraform_facts.yaml
     content: |
       ${indent(6, terraform_facts)}
+    permissions: "0640"
+%{ endif ~}
+%{ if puppetfile != "" ~}
+  - path: /etc/puppetlabs/Puppetfile
+    content: |
+      ${indent(6, puppetfile)}
     permissions: "0640"
 %{ endif ~}
 %{ endif ~}

--- a/common/configuration/puppet.yaml
+++ b/common/configuration/puppet.yaml
@@ -175,7 +175,7 @@ ssh_keys:
 
 disable_ec2_metadata: false
 timezone: "UTC"
-fqdn: "${node_name}"
+fqdn: "${node_name}.int.${domain_name}"
 manage_etc_hosts: false
 output: { all: "| tee -a /var/log/cloud-init-output.log" }
 power_state:

--- a/common/variables.tf
+++ b/common/variables.tf
@@ -160,3 +160,15 @@ variable "software_stack" {
 variable "pool" {
   default = []
 }
+
+variable "skip_upgrade" {
+  type        = bool
+  default     = false
+  description = "If set to true, the packages already installed in the base image will not be upgraded on first boot."
+}
+
+variable "puppetfile" {
+  type        = string
+  default     = ""
+  description = "Additional content for the pupet environment Puppetfile. If the string includes a `forge` setting, the string replaces the original Puppetfile completely."
+}

--- a/dns/cloudflare/main.tf
+++ b/dns/cloudflare/main.tf
@@ -10,6 +10,7 @@ module "record_generator" {
   source         = "../record_generator"
   name           = lower(var.name)
   public_instances = var.public_instances
+  vhosts           = var.vhosts
   domain_tag       = var.domain_tag
   vhost_tag        = var.vhost_tag
 }

--- a/dns/cloudflare/variables.tf
+++ b/dns/cloudflare/variables.tf
@@ -10,6 +10,12 @@ variable "email" {
 variable "sudoer_username" {
 }
 
+variable "vhosts" {
+  description = "List of vhost records A to create."
+  type    = list(string)
+  default = ["ipa", "jupyter", "mokey", "explore"]
+}
+
 variable "domain_tag" {
   description = "Indicate which tag the instances that will be pointed by the domain name A record has to have."
   default     = "login"

--- a/dns/gcloud/main.tf
+++ b/dns/gcloud/main.tf
@@ -7,6 +7,7 @@ module "record_generator" {
   source         = "../record_generator"
   name           = lower(var.name)
   public_instances = var.public_instances
+  vhosts           = var.vhosts
   domain_tag       = var.domain_tag
   vhost_tag        = var.vhost_tag
 }
@@ -18,7 +19,7 @@ resource "google_dns_record_set" "records" {
   name         = join(".", [module.record_generator.records[count.index].name, var.domain, ""])
   type         = module.record_generator.records[count.index].type
   rrdatas      = [module.record_generator.records[count.index].type != "SSHFP" ?
-                  module.record_generator.records[count.index].value : 
+                  module.record_generator.records[count.index].value :
                   join(" ", [module.record_generator.records[count.index].data["algorithm"],
                              module.record_generator.records[count.index].data["type"],
                              module.record_generator.records[count.index].data["fingerprint"]])

--- a/dns/gcloud/variables.tf
+++ b/dns/gcloud/variables.tf
@@ -21,6 +21,12 @@ variable "acme_key_pem" {
 variable "sudoer_username" {
 }
 
+variable "vhosts" {
+  description = "List of vhost records A to create."
+  type    = list(string)
+  default = ["ipa", "jupyter", "mokey", "explore"]
+}
+
 variable "domain_tag" {
   description = "Indicate which tag the instances that will be pointed by the domain name A record has to have."
   default     = "login"

--- a/dns/record_generator/main.tf
+++ b/dns/record_generator/main.tf
@@ -2,8 +2,6 @@ variable "name" {
 }
 
 variable "vhosts" {
-    type    = list(string)
-    default = ["ipa", "jupyter", "mokey", "explore"]
 }
 
 variable "public_instances" {}

--- a/docs/README.md
+++ b/docs/README.md
@@ -840,6 +840,30 @@ managed by the workload scheduler through Terraform API. For more information, r
 will be instantiated, others will stay uninstantiated or will be destroyed
 if previously instantiated.
 
+### 4.18 skip_upgrade (optional)
+
+**default_value** = `false`
+
+Determines wether the base image packages will be upgraded during the first boot or not. By default,
+all packages are upgraded. If `skip_upgrade` set to `true`, no package will be upgraded on first boot.
+
+**Post build modification effect**: No effect on currently built instnaces and instances created
+after the modification will take into consideration the new value of the parameter to determine
+wether they should upgrade the base image packages or not.
+
+### 4.19 puppetfile (optional)
+
+**default_value** = `""`
+
+Defines a complement of modules to install with librarian puppet when initializing the Puppet environment
+on the first boot of the Puppet server. If the provided string include the
+[`forge` setting](https://www.puppet.com/docs/pe/2019.8/puppetfile.html#declare_puppet_forge_modules_in_the_puppetfile),
+the provided content will replace entirely the Magic Castle environment's
+[Puppetfile](https://github.com/ComputeCanada/puppet-magic_castle/blob/main/Puppetfile).
+
+**Post build modification effect**: None. To modify the Puppetfile after the cluster is initialized, log
+on the Puppet server and modify `/etc/puppetlabs/code/environments/production/Puppetfile`.
+
 ## 5. Cloud Specific Configuration
 
 ### 5.1 Amazon Web Services

--- a/docs/README.md
+++ b/docs/README.md
@@ -844,12 +844,12 @@ if previously instantiated.
 
 **default_value** = `false`
 
-Determines wether the base image packages will be upgraded during the first boot or not. By default,
+Determines whether the base image packages will be upgraded during the first boot or not. By default,
 all packages are upgraded. If `skip_upgrade` set to `true`, no package will be upgraded on first boot.
 
-**Post build modification effect**: No effect on currently built instnaces and instances created
+**Post build modification effect**: No effect on currently built instances. Ones created
 after the modification will take into consideration the new value of the parameter to determine
-wether they should upgrade the base image packages or not.
+whether they should upgrade the base image packages or not.
 
 ### 4.19 puppetfile (optional)
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -250,7 +250,7 @@ for the initial configuration.
 instance's id to which the volume needs to be attached.
 
 13. **Identify the public instances**. In `infrastructure.tf`, define a local variable named `public_instances`
-that contains the attributes of instances that are publically accessible from Internet and their ids.
+that contains the attributes of instances that are publicly accessible from Internet and their ids.
   ```hcl
   locals {
     public_instances = { for host in keys(module.design.instances_to_build):
@@ -430,7 +430,7 @@ Alibaba cloud has an answer for each resource, so we will use this provider in t
   ```
 
 13. **Identify the public instances**. In `infrastructure.tf`, define a local variable named `public_instances`
-that contains the attributes of instances that are publically accessible from Internet and their ids.
+that contains the attributes of instances that are publicly accessible from Internet and their ids.
   ```hcl
   locals {
     public_instances = { for host in keys(module.design.instances_to_build):

--- a/gcp/infrastructure.tf
+++ b/gcp/infrastructure.tf
@@ -28,6 +28,8 @@ module "configuration" {
   software_stack        = var.software_stack
   cloud_provider        = local.cloud_provider
   cloud_region          = local.cloud_region
+  skip_upgrade          = var.skip_upgrade
+  puppetfile            = var.puppetfile
 }
 
 module "provision" {

--- a/openstack/infrastructure.tf
+++ b/openstack/infrastructure.tf
@@ -23,6 +23,8 @@ module "configuration" {
   software_stack        = var.software_stack
   cloud_provider        = local.cloud_provider
   cloud_region          = local.cloud_region
+  skip_upgrade          = var.skip_upgrade
+  puppetfile            = var.puppetfile
 }
 
 module "provision" {


### PR DESCRIPTION
This PR is meant to be merged in conjunction with the branch of the same name `includes` in puppet-magic_castle repo.

The PR introduces the following changes:
- Added `skip_upgrade` optional input variable to skip upgrading packages during cloud-init.
- Added `puppetfile` optional input variable to add modules to install or redefine the entire file if a forge command is provided.
- Changed the FQDN set by cloud-init from just the node name to node_name.int.domain_name. 
- Added variable vhosts to cloudflare and gcloud dns. This allows the definition of supplemental subdomains and vhost without much effort directly from the main.tf and hieradata.