### PR TITLE
Make issuing wilcard ssl certificate optional

### DIFF
--- a/dns/acme/main.tf
+++ b/dns/acme/main.tf
@@ -1,7 +1,3 @@
-provider "acme" {
-  server_url = "https://acme-v02.api.letsencrypt.org/directory"
-}
-
 variable "name" {
 }
 

--- a/dns/cloudflare/main.tf
+++ b/dns/cloudflare/main.tf
@@ -1,3 +1,7 @@
+provider "acme" {
+  server_url = "https://acme-v02.api.letsencrypt.org/directory"
+}
+
 data "cloudflare_zones" "domain" {
   filter {
     name   = var.domain
@@ -32,6 +36,7 @@ resource "cloudflare_record" "records" {
 }
 
 module "acme" {
+  count            = var.issue_wildcard_cert ? 1 : 0
   source           = "../acme"
   dns_provider     = "cloudflare"
   name             = lower(var.name)

--- a/dns/cloudflare/variables.tf
+++ b/dns/cloudflare/variables.tf
@@ -5,29 +5,42 @@ variable "domain" {
 }
 
 variable "email" {
+  description = "Define the email address used to issue the wildcard certificate. This address will get certificate expiration reminder."
+  type    = string
+  default = ""
+}
+
+variable "issue_wildcard_cert" {
+  description = "Use DNS-01 challenge to generate a wildcard certificate *.name.domain_name"
+  default     = false
+}
+
+variable "acme_key_pem" {
+  type = string
+  default = ""
 }
 
 variable "sudoer_username" {
 }
 
 variable "vhosts" {
-  description = "List of vhost records A to create."
+  description = "List of vhost dns records to create as vhost.name.domain_name."
   type    = list(string)
   default = ["ipa", "jupyter", "mokey", "explore"]
 }
 
 variable "domain_tag" {
-  description = "Indicate which tag the instances that will be pointed by the domain name A record has to have."
+  description = "Define the tag the instances that will be pointed by the domain name A record has to have."
   default     = "login"
 }
 
 variable "vhost_tag" {
-  description = "Indicate which tag the instances that will be pointed by the vhost A record has to have."
+  description = "Define the tag the instances that will be pointed by the vhost A record has to have."
   default = "proxy"
 }
 
 variable "ssl_tags" {
-  description = "Indicate which tag the instances that will receive a copy of the wildcard SSL certificate has to have."
+  description = "Define a list of tags the instances that will receive a copy of the wildcard SSL certificate can have."
   default = ["proxy", "ssl"]
 }
 
@@ -37,9 +50,4 @@ variable "bastions" { }
 
 variable "ssh_private_key" {
   type = string
-}
-
-variable "acme_key_pem" {
-  type = string
-  default = ""
 }

--- a/dns/cloudflare/versions.tf
+++ b/dns/cloudflare/versions.tf
@@ -5,5 +5,14 @@ terraform {
     cloudflare = {
       source = "cloudflare/cloudflare"
     }
+    acme = {
+      source = "vancluever/acme"
+    }
+    null = {
+      source = "hashicorp/null"
+    }
+    tls = {
+      source = "hashicorp/tls"
+    }
   }
 }

--- a/dns/gcloud/main.tf
+++ b/dns/gcloud/main.tf
@@ -1,3 +1,7 @@
+provider "acme" {
+  server_url = "https://acme-v02.api.letsencrypt.org/directory"
+}
+
 data "google_dns_managed_zone" "domain" {
   name    = var.zone_name
   project = var.project
@@ -28,6 +32,7 @@ resource "google_dns_record_set" "records" {
 }
 
 module "acme" {
+  count               = var.issue_wildcard_cert ? 1 : 0
   source              = "../acme"
   dns_provider        = "gcloud"
   dns_provider_config = {

--- a/dns/gcloud/variables.tf
+++ b/dns/gcloud/variables.tf
@@ -11,6 +11,14 @@ variable "domain" {
 }
 
 variable "email" {
+  description = "Define the email address used to issue the wildcard certificate. This address will get certificate expiration reminder."
+  type        = string
+  default     = ""
+}
+
+variable "issue_wildcard_cert" {
+  description = "Use DNS-01 challenge to generate a wildcard certificate *.name.domain_name"
+  default     = false
 }
 
 variable "acme_key_pem" {
@@ -22,23 +30,23 @@ variable "sudoer_username" {
 }
 
 variable "vhosts" {
-  description = "List of vhost records A to create."
+  description = "List of vhost dns records to create as vhost.name.domain_name."
   type    = list(string)
   default = ["ipa", "jupyter", "mokey", "explore"]
 }
 
 variable "domain_tag" {
-  description = "Indicate which tag the instances that will be pointed by the domain name A record has to have."
+  description = "Define the tag the instances that will be pointed by the domain name A record has to have."
   default     = "login"
 }
 
 variable "vhost_tag" {
-  description = "Indicate which tag the instances that will be pointed by the vhost A record has to have."
+  description = "Define the tag the instances that will be pointed by the vhost A record has to have."
   default = "proxy"
 }
 
 variable "ssl_tags" {
-  description = "Indicate which tag the instances that will receive a copy of the wildcard SSL certificate has to have."
+  description = "Define a list of tags the instances that will receive a copy of the wildcard SSL certificate can have."
   default = ["proxy", "ssl"]
 }
 

--- a/dns/gcloud/versions.tf
+++ b/dns/gcloud/versions.tf
@@ -5,5 +5,14 @@ terraform {
     google = {
       source = "hashicorp/google"
     }
+    acme = {
+      source = "vancluever/acme"
+    }
+    null = {
+      source = "hashicorp/null"
+    }
+    tls = {
+      source = "hashicorp/tls"
+    }
   }
 }

--- a/examples/advanced/basic_puppet/openstack/main.tf
+++ b/examples/advanced/basic_puppet/openstack/main.tf
@@ -33,7 +33,6 @@ output "sudoer" {
 ## Uncomment to register your domain name with CloudFlare
 # module "dns" {
 #   source           = "git::https://github.com/ComputeCanada/magic_castle.git//dns/cloudflare"
-#   email            = "you@example.com"
 #   name             = module.openstack.cluster_name
 #   domain           = module.openstack.domain
 #   bastions         = module.openstack.bastions
@@ -45,7 +44,6 @@ output "sudoer" {
 ## Uncomment to register your domain name with Google Cloud
 # module "dns" {
 #   source           = "git::https://github.com/ComputeCanada/magic_castle.git//dns/gcloud"
-#   email            = "you@example.com"
 #   project          = "your-project-id"
 #   zone_name        = "you-zone-name"
 #   name             = module.openstack.cluster_name

--- a/examples/advanced/k8s/openstack/main.tf
+++ b/examples/advanced/k8s/openstack/main.tf
@@ -33,7 +33,6 @@ output "public_ip" {
 ## Uncomment to register your domain name with CloudFlare
 # module "dns" {
 #   source           = "git::https://github.com/ComputeCanada/magic_castle.git//dns/cloudflare"
-#   email            = "you@example.com"
 #   name             = module.openstack.cluster_name
 #   domain           = module.openstack.domain
 #   bastions         = module.openstack.bastions
@@ -45,7 +44,6 @@ output "public_ip" {
 ## Uncomment to register your domain name with Google Cloud
 # module "dns" {
 #   source           = "git::https://github.com/ComputeCanada/magic_castle.git//dns/gcloud"
-#   email            = "you@example.com"
 #   project          = "your-project-id"
 #   zone_name        = "you-zone-name"
 #   name             = module.openstack.cluster_name

--- a/examples/advanced/lustre/openstack/main.tf
+++ b/examples/advanced/lustre/openstack/main.tf
@@ -42,7 +42,6 @@ output "sudoer" {
 ## Uncomment to register your domain name with CloudFlare
 # module "dns" {
 #   source           = "git::https://github.com/ComputeCanada/magic_castle.git//dns/cloudflare"
-#   email            = "you@example.com"
 #   name             = module.openstack.cluster_name
 #   domain           = module.openstack.domain
 #   bastions         = module.openstack.bastions
@@ -54,7 +53,6 @@ output "sudoer" {
 ## Uncomment to register your domain name with Google Cloud
 # module "dns" {
 #   source           = "git::https://github.com/ComputeCanada/magic_castle.git//dns/gcloud"
-#   email            = "you@example.com"
 #   project          = "your-project-id"
 #   zone_name        = "you-zone-name"
 #   name             = module.openstack.cluster_name

--- a/examples/advanced/spot_instances/aws/main.tf
+++ b/examples/advanced/spot_instances/aws/main.tf
@@ -51,7 +51,6 @@ output "public_ip" {
 ## Uncomment to register your domain name with CloudFlare
 # module "dns" {
 #   source           = "git::https://github.com/ComputeCanada/magic_castle.git//dns/cloudflare"
-#   email            = "you@example.com"
 #   name             = module.aws.cluster_name
 #   domain           = module.aws.domain
 #   bastions         = module.aws.bastions
@@ -63,7 +62,6 @@ output "public_ip" {
 ## Uncomment to register your domain name with Google Cloud
 # module "dns" {
 #   source           = "git::https://github.com/ComputeCanada/magic_castle.git//dns/gcloud"
-#   email            = "you@example.com"
 #   project          = "your-project-id"
 #   zone_name        = "you-zone-name"
 #   name             = module.aws.cluster_name

--- a/examples/advanced/spot_instances/azure/main.tf
+++ b/examples/advanced/spot_instances/azure/main.tf
@@ -55,7 +55,6 @@ output "public_ip" {
 ## Uncomment to register your domain name with CloudFlare
 # module "dns" {
 #   source           = "git::https://github.com/ComputeCanada/magic_castle.git//dns/cloudflare"
-#   email            = "you@example.com"
 #   name             = module.azure.cluster_name
 #   domain           = module.azure.domain
 #   bastions         = module.azure.bastions
@@ -67,7 +66,6 @@ output "public_ip" {
 ## Uncomment to register your domain name with Google Cloud
 # module "dns" {
 #   source           = "git::https://github.com/ComputeCanada/magic_castle.git//dns/gcloud"
-#   email            = "you@example.com"
 #   project          = "your-project-id"
 #   zone_name        = "you-zone-name"
 #   name             = module.azure.cluster_name

--- a/examples/advanced/spot_instances/gcp/main.tf
+++ b/examples/advanced/spot_instances/gcp/main.tf
@@ -51,7 +51,6 @@ output "public_ip" {
 ## Uncomment to register your domain name with CloudFlare
 # module "dns" {
 #   source           = "git::https://github.com/ComputeCanada/magic_castle.git//dns/cloudflare"
-#   email            = "you@example.com"
 #   name             = module.gcp.cluster_name
 #   domain           = module.gcp.domain
 #   bastions         = module.gcp.bastions
@@ -63,7 +62,6 @@ output "public_ip" {
 ## Uncomment to register your domain name with Google Cloud
 # module "dns" {
 #   source           = "git::https://github.com/ComputeCanada/magic_castle.git//dns/gcloud"
-#   email            = "you@example.com"
 #   project          = "your-project-id"
 #   zone_name        = "you-zone-name"
 #   name             = module.gcp.cluster_name

--- a/examples/aws/main.tf
+++ b/examples/aws/main.tf
@@ -59,7 +59,6 @@ output "public_ip" {
 ## Uncomment to register your domain name with CloudFlare
 # module "dns" {
 #   source           = "git::https://github.com/ComputeCanada/magic_castle.git//dns/cloudflare"
-#   email            = "you@example.com"
 #   name             = module.aws.cluster_name
 #   domain           = module.aws.domain
 #   bastions         = module.aws.bastions
@@ -71,7 +70,6 @@ output "public_ip" {
 ## Uncomment to register your domain name with Google Cloud
 # module "dns" {
 #   source           = "git::https://github.com/ComputeCanada/magic_castle.git//dns/gcloud"
-#   email            = "you@example.com"
 #   project          = "your-project-id"
 #   zone_name        = "you-zone-name"
 #   name             = module.aws.cluster_name

--- a/examples/azure/main.tf
+++ b/examples/azure/main.tf
@@ -70,7 +70,6 @@ output "public_ip" {
 ## Uncomment to register your domain name with CloudFlare
 # module "dns" {
 #   source           = "git::https://github.com/ComputeCanada/magic_castle.git//dns/cloudflare"
-#   email            = "you@example.com"
 #   name             = module.azure.cluster_name
 #   domain           = module.azure.domain
 #   bastions         = module.azure.bastions
@@ -82,7 +81,6 @@ output "public_ip" {
 ## Uncomment to register your domain name with Google Cloud
 # module "dns" {
 #   source           = "git::https://github.com/ComputeCanada/magic_castle.git//dns/gcloud"
-#   email            = "you@example.com"
 #   project          = "your-project-id"
 #   zone_name        = "you-zone-name"
 #   name             = module.azure.cluster_name

--- a/examples/gcp/main.tf
+++ b/examples/gcp/main.tf
@@ -65,7 +65,6 @@ output "public_ip" {
 ## Uncomment to register your domain name with CloudFlare
 # module "dns" {
 #   source           = "git::https://github.com/ComputeCanada/magic_castle.git//dns/cloudflare"
-#   email            = "you@example.com"
 #   name             = module.gcp.cluster_name
 #   domain           = module.gcp.domain
 #   bastions         = module.gcp.bastions
@@ -77,7 +76,6 @@ output "public_ip" {
 ## Uncomment to register your domain name with Google Cloud
 # module "dns" {
 #   source           = "git::https://github.com/ComputeCanada/magic_castle.git//dns/gcloud"
-#   email            = "you@example.com"
 #   project          = "your-project-id"
 #   zone_name        = "you-zone-name"
 #   name             = module.gcp.cluster_name

--- a/examples/openstack/main.tf
+++ b/examples/openstack/main.tf
@@ -54,7 +54,6 @@ output "public_ip" {
 ## Uncomment to register your domain name with CloudFlare
 # module "dns" {
 #   source           = "git::https://github.com/ComputeCanada/magic_castle.git//dns/cloudflare"
-#   email            = "you@example.com"
 #   name             = module.openstack.cluster_name
 #   domain           = module.openstack.domain
 #   bastions         = module.openstack.bastions
@@ -66,7 +65,6 @@ output "public_ip" {
 ## Uncomment to register your domain name with Google Cloud
 # module "dns" {
 #   source           = "git::https://github.com/ComputeCanada/magic_castle.git//dns/gcloud"
-#   email            = "you@example.com"
 #   project          = "your-project-id"
 #   zone_name        = "you-zone-name"
 #   name             = module.openstack.cluster_name

--- a/examples/ovh/main.tf
+++ b/examples/ovh/main.tf
@@ -54,7 +54,6 @@ output "public_ip" {
 ## Uncomment to register your domain name with CloudFlare
 # module "dns" {
 #   source           = "git::https://github.com/ComputeCanada/magic_castle.git//dns/cloudflare"
-#   email            = "you@example.com"
 #   name             = module.ovh.cluster_name
 #   domain           = module.ovh.domain
 #   bastions         = module.ovh.bastions
@@ -66,7 +65,6 @@ output "public_ip" {
 ## Uncomment to register your domain name with Google Cloud
 # module "dns" {
 #   source           = "git::https://github.com/ComputeCanada/magic_castle.git//dns/gcloud"
-#   email            = "you@example.com"
 #   project          = "your-project-id"
 #   zone_name        = "you-zone-name"
 #   name             = module.ovh.cluster_name


### PR DESCRIPTION
The generation of the wildcard certificate is no longer necessary as caddy handles certificate generation per vhost by itself and also handle renewal automatically. The wildcard generation was meant to be used when multiple proxy / jupyterhub would be used, but this has yet proven useful. Therefore, we are making the wildcard generation an exception instead of the general rule.