### PR TITLE
Replace librarian-puppet by R10k

### DIFF
--- a/common/configuration/puppet.yaml
+++ b/common/configuration/puppet.yaml
@@ -55,7 +55,7 @@ runcmd:
   - systemctl daemon-reload
   - systemctl enable puppetserver
 # Install gem dependencies
-  - "/opt/puppetlabs/puppet/bin/gem install autosign:1.0.1 hiera-eyaml:3.4.0 r10k:4.0.0"
+  - "/opt/puppetlabs/puppet/bin/gem install autosign:1.0.1 hiera-eyaml:3.4.0 puppet_forge:4.1.0 r10k:4.0.0"
 # Enable autosign with password
   - chgrp puppet /etc/autosign.conf
   - chown puppet:puppet /var/log/autosign.log

--- a/common/configuration/puppet.yaml
+++ b/common/configuration/puppet.yaml
@@ -37,7 +37,7 @@ runcmd:
 %{ endif ~}
       # Puppet agent configuration and install
       yum -y install https://yum.puppet.com/puppet7-release-el-$(grep -oP 'VERSION_ID="\K[^"]' /etc/os-release).noarch.rpm
-      yum -y install puppet-agent-7.24.0
+      yum -y install puppet-agent-7.26.0
       install -m 700 /dev/null /opt/puppetlabs/bin/postrun
       # kernel configuration
       systemctl disable kdump
@@ -47,7 +47,7 @@ runcmd:
     fi
 %{ if contains(tags, "puppet") }
 # Install Java 11 and puppetserver
-  - yum -y install java-11-openjdk-headless puppetserver-7.11.0
+  - yum -y install java-11-openjdk-headless puppetserver-7.13.0
 # Configure puppetserver to use Java 11
   - sudo sed -i 's;\(JAVA_BIN=\).*;\1"/usr/lib/jvm/jre-11/bin/java";g' /etc/sysconfig/puppetserver
 # Configure puppet-agent to start after puppetserver when on puppetserver

--- a/common/configuration/puppet.yaml
+++ b/common/configuration/puppet.yaml
@@ -46,7 +46,7 @@ runcmd:
       grub2-mkconfig -o /boot/grub2/grub.cfg
     fi
 %{ if contains(tags, "puppet") }
-  # Install Java 11 and puppetserver
+# Install Java 11 and puppetserver
   - yum -y install java-11-openjdk-headless puppetserver-7.11.0
 # Configure puppetserver to use Java 11
   - sudo sed -i 's;\(JAVA_BIN=\).*;\1"/usr/lib/jvm/jre-11/bin/java";g' /etc/sysconfig/puppetserver
@@ -54,14 +54,14 @@ runcmd:
   - sed -i 's/^\(After=.*\)$/\1 puppetserver.service/' /usr/lib/systemd/system/puppet.service
   - systemctl daemon-reload
   - systemctl enable puppetserver
+# Install gem dependencies
+  - "/opt/puppetlabs/puppet/bin/gem install autosign:1.0.1 hiera-eyaml:3.4.0 r10k:4.0.0"
 # Enable autosign with password
   - chgrp puppet /etc/autosign.conf
   - chown puppet:puppet /var/log/autosign.log
-  - /opt/puppetlabs/puppet/bin/gem install autosign
   - /opt/puppetlabs/bin/puppet config set autosign /opt/puppetlabs/puppet/bin/autosign-validator --section server
   - /opt/puppetlabs/bin/puppet config set allow_duplicate_certs true --section server
 # Generate hieradata asymmetric encryption key
-  - /opt/puppetlabs/puppet/bin/gem install hiera-eyaml
   - mkdir -p /etc/puppetlabs/puppet/eyaml
   - /opt/puppetlabs/puppet/bin/eyaml createkeys --pkcs7-private-key=/etc/puppetlabs/puppet/eyaml/private_key.pkcs7.pem --pkcs7-public-key=/etc/puppetlabs/puppet/eyaml/public_key.pkcs7.pem
   - /opt/puppetlabs/puppet/bin/eyaml createkeys --pkcs7-private-key=/etc/puppetlabs/puppet/eyaml/boot_private_key.pkcs7.pem --pkcs7-public-key=/etc/puppetlabs/puppet/eyaml/boot_public_key.pkcs7.pem
@@ -70,7 +70,8 @@ runcmd:
   - chmod 0400 /etc/puppetlabs/puppet/eyaml/boot_private_key.pkcs7.pem
 # Setup puppet environment code and modules
   - rm -rf /etc/puppetlabs/code/environments/production
-  - git clone ${puppetenv_git} /etc/puppetlabs/code/environments/production
+  - git clone ${puppetenv_git} /etc/puppetlabs/code/environments/main
+  - ln -s /etc/puppetlabs/code/environments/main /etc/puppetlabs/code/environments/production
   - "(cd /etc/puppetlabs/code/environments/production; git checkout ${puppetenv_rev})"
 %{ if puppetfile != "" ~}
 %{ if strcontains(puppetfile, "forge") ~}
@@ -85,10 +86,10 @@ runcmd:
   - ln -sf /etc/puppetlabs/data/terraform_data.yaml /etc/puppetlabs/code/environments/production/data/
   - ln -sf /etc/puppetlabs/data/user_data.yaml /etc/puppetlabs/code/environments/production/data/
   - ln -sf /etc/puppetlabs/facts/terraform_facts.yaml /etc/puppetlabs/code/environments/production/site/profile/facts.d
-  - /opt/puppetlabs/puppet/bin/gem install librarian-puppet
+# We use r10k solely to install the modules of the main branch environment.
+  - "(cd /etc/puppetlabs/code/environments/production; /opt/puppetlabs/puppet/bin/r10k puppetfile install)"
 # Wait for Terraform to scp its YAML data
   - while [ ! -e "/etc/puppetlabs/data/terraform_data.yaml" ]; do echo "$(date -I'seconds') Waiting for terraform to scp terraform_data.yaml"; sleep 5; done
-  - "(cd /etc/puppetlabs/code/environments/production/ && HOME=/root PATH=$PATH:/opt/puppetlabs/puppet/bin /opt/puppetlabs/puppet/bin/librarian-puppet install)"
 %{ if node_name != keys(puppetservers)[0] }
   - sed -e '/certificate-authority-service/ s/^/#/' -i /etc/puppetlabs/puppetserver/services.d/ca.cfg
   - sed -e '/certificate-authority-disabled-service/ s/^#//' -i /etc/puppetlabs/puppetserver/services.d/ca.cfg


### PR DESCRIPTION
librarian-puppet will eventually by deprecated and r10k has proven to be way faster when installing modules.

The downsides is that Puppetfile will have to include all dependencies from now on since r10k does not track them.