### PR TITLE
Fix version of faraday* gems in cloud-init

### DIFF
--- a/common/configuration/puppet.yaml
+++ b/common/configuration/puppet.yaml
@@ -55,7 +55,7 @@ runcmd:
   - systemctl daemon-reload
   - systemctl enable puppetserver
 # Install gem dependencies
-  - "/opt/puppetlabs/puppet/bin/gem install autosign:1.0.1 hiera-eyaml:3.4.0 puppet_forge:4.1.0 r10k:4.0.0"
+  - "/opt/puppetlabs/puppet/bin/gem install autosign:1.0.1 hiera-eyaml:3.4.0 faraday:2.8.1 faraday-net_http:3.0.2 puppet_forge:4.1.0 r10k:4.0.1"
 # Enable autosign with password
   - chgrp puppet /etc/autosign.conf
   - chown puppet:puppet /var/log/autosign.log


### PR DESCRIPTION
fadaray version >= 2.9 and faraday_net_http >= 3.1.0 released on January 9 2024 no longer support the Ruby version bundled with Puppet 7 - Ruby 2.8.

This PR fix the version of these packages.