### PR TITLE
Yaml validation on hierada

### DIFF
--- a/common/variables.tf
+++ b/common/variables.tf
@@ -88,6 +88,10 @@ variable "hieradata" {
   type        = string
   default     = "---"
   description = "String formatted as YAML defining hiera key-value pairs to be included in the puppet environment"
+  validation {
+    condition     = can(yamldecode(var.hieradata))
+    error_message = "Hieradata needs to be valid YAML"
+  }
 }
 
 variable "sudoer_username" {


### PR DESCRIPTION
close #269 

Simple validation to check if the `hierada` variable is valid YAML. This is the proposed solution for the issue.

It catches bad file formats, empty strings, and invalid strings.

