### PR TITLE
AlertManager documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -740,10 +740,31 @@ following line to the string:
     ```yaml
     jupyterhub::enable_otp_auth: false
     ```
+- Setup AlertManager to receive Prometheus alerts on Slack:
+    ```yaml
+    prometheus::alertmanager::route:
+      group_by:
+        - 'alertname'
+        - 'cluster'
+        - 'service'
+      group_wait: '5s'
+      group_interval: '5m'
+      repeat_interval: '3h'
+      receiver: 'slack'
+
+    prometheus::alertmanager::receivers:
+      - name: 'slack'
+        slack_configs:
+          - api_url: 'https://hooks.slack.com/services/ABCDEFG123456'
+            channel: "#channel"
+            send_resolved: true
+            username: 'username'
+    ```
 
 Refer to the following Puppet modules' documentation to know more about the key-values that can be defined:
 - [puppet-magic_castle](https://github.com/ComputeCanada/puppet-magic_castle/blob/main/README.md)
 - [puppet-jupyterhub](https://github.com/ComputeCanada/puppet-jupyterhub/blob/main/README.md#hieradata-configuration)
+- [puppet-prometheus](https://forge.puppet.com/modules/puppet/prometheus/)
 
 
 The file created from this string can be found on `puppet` as


### PR DESCRIPTION
This is really a small minimal example to receive Prometheus alerts on Slack. It doesn't show how to define new alerts to keep it small and not duplicate the original puppet-prometheus documentation.

If we want more complex examples, I would suggest to create a new documentation section ("Hieradata Advanced Examples") where we can show more complex hieradata use cases. We could also include [users disk quota](https://github.com/ComputeCanada/puppet-magic_castle/pull/308) examples in that section.

@cmd-ntrf  what do you think?