### PR TITLE
Hieradata per instances group

### DIFF
--- a/aws/infrastructure.tf
+++ b/aws/infrastructure.tf
@@ -42,6 +42,7 @@ module "provision" {
   terraform_data  = module.configuration.terraform_data
   terraform_facts = module.configuration.terraform_facts
   hieradata       = var.hieradata
+  hieradata_folder = var.hieradata_folder_path
   sudoer_username = var.sudoer_username
   eyaml_key       = var.eyaml_key
   depends_on      = [aws_instance.instances, aws_eip.public_ip]

--- a/aws/infrastructure.tf
+++ b/aws/infrastructure.tf
@@ -42,7 +42,7 @@ module "provision" {
   terraform_data  = module.configuration.terraform_data
   terraform_facts = module.configuration.terraform_facts
   hieradata       = var.hieradata
-  hieradata_folder = var.hieradata_folder_path
+  hieradata_dir   = var.hieradata_dir
   sudoer_username = var.sudoer_username
   eyaml_key       = var.eyaml_key
   depends_on      = [aws_instance.instances, aws_eip.public_ip]

--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -42,6 +42,7 @@ module "provision" {
   terraform_data  = module.configuration.terraform_data
   terraform_facts = module.configuration.terraform_facts
   hieradata       = var.hieradata
+  hieradata_folder = var.hieradata_folder_path
   sudoer_username = var.sudoer_username
   eyaml_key       = var.eyaml_key
   depends_on      = [ azurerm_linux_virtual_machine.instances ]

--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -42,7 +42,7 @@ module "provision" {
   terraform_data  = module.configuration.terraform_data
   terraform_facts = module.configuration.terraform_facts
   hieradata       = var.hieradata
-  hieradata_folder = var.hieradata_folder_path
+  hieradata_dir   = var.hieradata_dir
   sudoer_username = var.sudoer_username
   eyaml_key       = var.eyaml_key
   depends_on      = [ azurerm_linux_virtual_machine.instances ]

--- a/common/configuration/main.tf
+++ b/common/configuration/main.tf
@@ -86,7 +86,7 @@ locals {
   })
 
   terraform_facts = yamlencode({
-    software_stack = var.software_stack
+    software_stack = var.software_stack,
     cloud          = {
       provider = var.cloud_provider
       region = var.cloud_region
@@ -100,6 +100,7 @@ locals {
         cloud_provider        = var.cloud_provider
         tags                  = values.tags
         node_name             = key,
+        node_prefix           = values.prefix,
         domain_name           = var.domain_name
         puppetenv_git         = var.config_git_url,
         puppetenv_rev         = var.config_version,

--- a/common/configuration/puppet.yaml
+++ b/common/configuration/puppet.yaml
@@ -90,6 +90,7 @@ runcmd:
   - chgrp -R puppet /etc/puppetlabs/data /etc/puppetlabs/facts
   - ln -sf /etc/puppetlabs/data/terraform_data.yaml /etc/puppetlabs/code/environments/production/data/
   - ln -sf /etc/puppetlabs/data/user_data.yaml /etc/puppetlabs/code/environments/production/data/
+  - ln -sf /etc/puppetlabs/data/hieradata /etc/puppetlabs/code/environments/production/data/
   - ln -sf /etc/puppetlabs/facts/terraform_facts.yaml /etc/puppetlabs/code/environments/production/site/profile/facts.d
 # We use r10k solely to install the modules of the main branch environment.
   - "(cd /etc/puppetlabs/code/environments/production; /opt/puppetlabs/puppet/bin/r10k puppetfile install)"
@@ -140,8 +141,17 @@ write_files:
           %{ if cloud_provider != "gcp" } "GCE", %{ endif }
         ],
       }
+      global : {
+        external-dir : ["/etc/puppetlabs/facts/external"],
+      }
+
     path: /etc/puppetlabs/facter/facter.conf
     permissions: "0644"
+  - path: /etc/puppetlabs/facts/external/prefix.yaml
+    content: |
+      ---
+      prefix : "${node_prefix}"
+    permissions: "0640"
 %{ if contains(tags, "puppet") ~}
   - content: |
       ---

--- a/common/configuration/puppet.yaml
+++ b/common/configuration/puppet.yaml
@@ -139,17 +139,14 @@ write_files:
           %{ if cloud_provider != "gcp" } "GCE", %{ endif }
         ],
       }
-      global : {
-        external-dir : ["/etc/puppetlabs/facts/external"],
-      }
 
     path: /etc/puppetlabs/facter/facter.conf
     permissions: "0644"
-  - path: /etc/puppetlabs/facts/external/prefix.yaml
+  - path: /etc/puppetlabs/facter/facts.d/prefix.yaml
     content: |
       ---
       prefix : "${node_prefix}"
-    permissions: "0640"
+    permissions: "0644"
 %{ if contains(tags, "puppet") ~}
   - content: |
       ---

--- a/common/configuration/puppet.yaml
+++ b/common/configuration/puppet.yaml
@@ -88,9 +88,7 @@ runcmd:
 %{ endif ~}
   - mkdir -p /etc/puppetlabs/data /etc/puppetlabs/facts
   - chgrp -R puppet /etc/puppetlabs/data /etc/puppetlabs/facts
-  - ln -sf /etc/puppetlabs/data/terraform_data.yaml /etc/puppetlabs/code/environments/production/data/
-  - ln -sf /etc/puppetlabs/data/user_data.yaml /etc/puppetlabs/code/environments/production/data/
-  - ln -sf /etc/puppetlabs/data/hieradata /etc/puppetlabs/code/environments/production/data/
+  - ln -sf /etc/puppetlabs/data/{user_data,user_data.yaml,terraform_data.yaml} /etc/puppetlabs/code/environments/production/data/
   - ln -sf /etc/puppetlabs/facts/terraform_facts.yaml /etc/puppetlabs/code/environments/production/site/profile/facts.d
 # We use r10k solely to install the modules of the main branch environment.
   - "(cd /etc/puppetlabs/code/environments/production; /opt/puppetlabs/puppet/bin/r10k puppetfile install)"

--- a/common/provision/main.tf
+++ b/common/provision/main.tf
@@ -41,7 +41,7 @@ data "archive_file" "puppetserver_files" {
   }
 
   dynamic "source" {
-    for_each = var.hieradata_dir != "" ? fileset("${var.hieradata_dir}", "{prefix,hostname}/**/*.yaml") : []
+    for_each = var.hieradata_dir != "" ? fileset("${var.hieradata_dir}", "{prefixes,hostnames}/**/*.yaml") : []
     iterator = filename
     content {
       content  = file("${var.hieradata_dir}/${filename.value}")

--- a/common/provision/main.tf
+++ b/common/provision/main.tf
@@ -87,7 +87,8 @@ resource "terraform_data" "deploy_puppetserver_files" {
       "sudo chmod g-w,o-rwx $(find ${local.provision_folder}/ -type f)",
       "sudo chown -R root:52 ${local.provision_folder}",
       "sudo mkdir -p -m 755 /etc/puppetlabs/",
-      "sudo rsync -avh --no-t ${local.provision_folder}/ /etc/puppetlabs/",
+      "sudo rsync -avh --no-t --exclude 'data' ${local.provision_folder}/ /etc/puppetlabs/",
+      "sudo rsync -avh --no-t --del ${local.provision_folder}/data/ /etc/puppetlabs/data/",
       "sudo rm -rf ${local.provision_folder}/ ${local.provision_folder}.zip",
       "[ -f /usr/local/bin/consul ] && [ -f /usr/bin/jq ] && consul event -token=$(sudo jq -r .acl.tokens.agent /etc/consul/config.json) -name=puppet $(date +%s) || true",
     ]

--- a/common/provision/main.tf
+++ b/common/provision/main.tf
@@ -32,16 +32,7 @@ data "archive_file" "puppetserver_files" {
   }
 
   dynamic "source" {
-    for_each = var.hieradata_dir != "" ? fileset("${var.hieradata_dir}", "*.yaml") : []
-    iterator = filename
-    content {
-      content  = file("${var.hieradata_dir}/${filename.value}")
-      filename = "${local.provision_folder}/data/user_data/${filename.value}"
-    }
-  }
-
-  dynamic "source" {
-    for_each = var.hieradata_dir != "" ? fileset("${var.hieradata_dir}", "{prefixes,hostnames}/**/*.yaml") : []
+    for_each = var.hieradata_dir != "" ? fileset("${var.hieradata_dir}", "**/*.yaml") : []
     iterator = filename
     content {
       content  = file("${var.hieradata_dir}/${filename.value}")

--- a/common/provision/main.tf
+++ b/common/provision/main.tf
@@ -2,59 +2,94 @@ variable "bastions" { }
 variable "puppetservers" { }
 variable "terraform_data" { }
 variable "terraform_facts" { }
+variable "hieradata_folder" { }
 variable "hieradata" { }
 variable "sudoer_username" { }
 variable "tf_ssh_key" { }
 variable "eyaml_key" { }
 
+data "local_file" "hieradata_yaml" {
+  for_each = var.hieradata_folder != "" ? fileset("${var.hieradata_folder}", "*.yaml") : []
+  filename = "${var.hieradata_folder}/${each.value}"
+}
+
+data "local_file" "hieradata_subfolder" {
+  for_each = var.hieradata_folder != "" ? fileset("${var.hieradata_folder}", "{prefix,hostname}/**/*.yaml") : []
+  filename = "${var.hieradata_folder}/${each.value}"
+}
+
 locals {
-  provision_folder = "puppetserver_etc"
-}
-
-data "archive_file" "puppetserver_files" {
-  type        = "zip"
-  output_path = "${path.module}/files/${local.provision_folder}.zip"
-
-  source {
-    content  = var.terraform_data
-    filename = "${local.provision_folder}/data/terraform_data.yaml"
-  }
-
-  source {
-    content  = var.terraform_facts
-    filename = "${local.provision_folder}/facts/terraform_facts.yaml"
-  }
-
-  source {
-    content  = var.hieradata
-    filename = "${local.provision_folder}/data/user_data.yaml"
-  }
-
-  dynamic "source" {
-    for_each =  var.eyaml_key != "" ? [var.eyaml_key] : []
-    content {
-      content  = var.eyaml_key
-      filename = "${local.provision_folder}/puppet/eyaml/private_key.pkcs7.pem"
-    }
-  }
-}
-
-resource "terraform_data" "deploy_puppetserver_files" {
-  for_each = length(var.bastions) > 0  ? var.puppetservers : { }
-
-  connection {
-    type                = "ssh"
+  connection_parameters = length(var.bastions) > 0 ? {
     bastion_host        = var.bastions[keys(var.bastions)[0]].public_ip
     bastion_user        = var.sudoer_username
     bastion_private_key = var.tf_ssh_key.private
     user                = var.sudoer_username
-    host                = each.value
     private_key         = var.tf_ssh_key.private
+  } : null
+
+  hieradata_md5 = merge(
+    {for value in data.local_file.hieradata_yaml: replace(value.filename, var.hieradata_folder, "") => value.content_md5},
+    {for value in data.local_file.hieradata_subfolder: replace(value.filename, var.hieradata_folder, "") => value.content_md5},
+  )
+  triggers_hieradata_folder = {
+    hieradata_yaml  = local.hieradata_md5
   }
 
-  triggers_replace = {
-    archive = data.archive_file.puppetserver_files.output_sha256
+  triggers_hieradata = {
+    user_data      = md5(var.hieradata)
+    terraform_data = md5(var.terraform_data)
+    facts          = md5(var.terraform_facts)
   }
+}
+
+resource "terraform_data" "deploy_hieradata_folder" {
+  for_each = local.connection_parameters != null && length(local.hieradata_md5) > 0 ? var.puppetservers : { }
+
+  connection {
+    type                = "ssh"
+    host                = each.value
+    bastion_host        = local.connection_parameters["bastion_host"]
+    bastion_user        = local.connection_parameters["bastion_user"]
+    bastion_private_key = local.connection_parameters["bastion_private_key"]
+    user                = local.connection_parameters["user"]
+    private_key         = local.connection_parameters["private_key"]
+  }
+
+  triggers_replace = local.triggers_hieradata_folder
+
+  provisioner "file" {
+    source      = "${path.cwd}/hieradata"
+    destination = "hieradata"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      # clean up
+      "sudo rm -rf /etc/puppetlabs/data/hieradata || true",
+      "sudo mkdir -p /etc/puppetlabs/data",
+      # puppet user and group have been assigned the reserved UID/GID 52
+      "sudo cp -r hieradata /etc/puppetlabs/data/",
+      "sudo chown -R root:52 /etc/puppetlabs/data/hieradata",
+      "sudo chmod -R 650 /etc/puppetlabs/data/hieradata",
+      "rm -rf hieradata",
+    ]
+  }
+}
+
+resource "terraform_data" "deploy_hieradata" {
+  for_each = local.connection_parameters != null ? var.puppetservers : { }
+
+  connection {
+    type                = "ssh"
+    host                = each.value
+    bastion_host        = local.connection_parameters["bastion_host"]
+    bastion_user        = local.connection_parameters["bastion_user"]
+    bastion_private_key = local.connection_parameters["bastion_private_key"]
+    user                = local.connection_parameters["user"]
+    private_key         = local.connection_parameters["private_key"]
+  }
+
+  triggers_replace = local.triggers_hieradata
 
   provisioner "file" {
     source      = "${path.module}/files/${local.provision_folder}.zip"
@@ -63,14 +98,41 @@ resource "terraform_data" "deploy_puppetserver_files" {
 
   provisioner "remote-exec" {
     inline = [
-      # unzip is not necessarily installed when connecting, but python is.
-      "/usr/libexec/platform-python -c 'import zipfile; zipfile.ZipFile(\"${local.provision_folder}.zip\").extractall()'",
-      "sudo chmod g-w,o-rwx $(find ${local.provision_folder}/ -type f)",
-      "sudo chown -R root:52 ${local.provision_folder}",
-      "sudo mkdir -p -m 755 /etc/puppetlabs/",
-      "sudo rsync -avh --no-t ${local.provision_folder}/ /etc/puppetlabs/",
-      "sudo rm -rf ${local.provision_folder}/ ${local.provision_folder}.zip",
-      "[ -f /usr/local/bin/consul ] && [ -f /usr/bin/jq ] && consul event -token=$(sudo jq -r .acl.tokens.agent /etc/consul/config.json) -name=puppet $(date +%s) || true",
+      "sudo mkdir -p /etc/puppetlabs/data /etc/puppetlabs/facts",
+      # puppet user and group have been assigned the reserved UID/GID 52
+      "sudo install -o root -g 52 -m 640 terraform_data.yaml user_data.yaml /etc/puppetlabs/data/",
+      "sudo install -o root -g 52 -m 640 terraform_facts.yaml /etc/puppetlabs/facts/",
+      "rm -f terraform_data.yaml user_data.yaml terraform_facts.yaml",
+    ]
+  }
+}
+
+resource "terraform_data" "update_consul" {
+  for_each = local.connection_parameters != null ? var.puppetservers : { }
+
+  connection {
+    type                = "ssh"
+    host                = each.value
+    bastion_host        = local.connection_parameters["bastion_host"]
+    bastion_user        = local.connection_parameters["bastion_user"]
+    bastion_private_key = local.connection_parameters["bastion_private_key"]
+    user                = local.connection_parameters["user"]
+    private_key         = local.connection_parameters["private_key"]
+  }
+
+  triggers_replace = merge(
+    local.triggers_hieradata,
+    local.triggers_hieradata_folder,
+  )
+
+  depends_on = [
+      terraform_data.deploy_hieradata,
+      terraform_data.deploy_hieradata_folder,
+    ]
+
+  provisioner "remote-exec" {
+    inline = [
+      "[ -f /usr/local/bin/consul ] && [ -f /usr/bin/jq ] && consul event -token=$(sudo jq -r .acl.tokens.agent /etc/consul/config.json) -name=puppet $(date +%s) || true"
     ]
   }
 }

--- a/common/provision/main.tf
+++ b/common/provision/main.tf
@@ -3,7 +3,7 @@ variable "puppetservers" { }
 variable "terraform_data" { }
 variable "terraform_facts" { }
 variable "hieradata" { }
-variable "hieradata_folder" { }
+variable "hieradata_dir" { }
 variable "sudoer_username" { }
 variable "tf_ssh_key" { }
 variable "eyaml_key" { }
@@ -26,26 +26,25 @@ data "archive_file" "puppetserver_files" {
     filename = "${local.provision_folder}/facts/terraform_facts.yaml"
   }
 
-
   source {
     content  = var.hieradata
     filename = "${local.provision_folder}/data/user_data.yaml"
   }
 
   dynamic "source" {
-    for_each = var.hieradata_folder != "" ? fileset("${var.hieradata_folder}", "*.yaml") : []
+    for_each = var.hieradata_dir != "" ? fileset("${var.hieradata_dir}", "*.yaml") : []
     iterator = filename
     content {
-      content  = file("${var.hieradata_folder}/${filename.value}")
+      content  = file("${var.hieradata_dir}/${filename.value}")
       filename = "${local.provision_folder}/data/${filename.value}"
     }
   }
 
   dynamic "source" {
-    for_each = var.hieradata_folder != "" ? fileset("${var.hieradata_folder}", "{prefix,hostname}/**/*.yaml") : []
+    for_each = var.hieradata_dir != "" ? fileset("${var.hieradata_dir}", "{prefix,hostname}/**/*.yaml") : []
     iterator = filename
     content {
-      content  = file("${var.hieradata_folder}/${filename.value}")
+      content  = file("${var.hieradata_dir}/${filename.value}")
       filename = "${local.provision_folder}/data/${filename.value}"
     }
   }

--- a/common/provision/main.tf
+++ b/common/provision/main.tf
@@ -36,7 +36,7 @@ data "archive_file" "puppetserver_files" {
     iterator = filename
     content {
       content  = file("${var.hieradata_dir}/${filename.value}")
-      filename = "${local.provision_folder}/data/${filename.value}"
+      filename = "${local.provision_folder}/data/user_data/${filename.value}"
     }
   }
 
@@ -45,7 +45,7 @@ data "archive_file" "puppetserver_files" {
     iterator = filename
     content {
       content  = file("${var.hieradata_dir}/${filename.value}")
-      filename = "${local.provision_folder}/data/${filename.value}"
+      filename = "${local.provision_folder}/data/user_data/${filename.value}"
     }
   }
 

--- a/common/provision/main.tf
+++ b/common/provision/main.tf
@@ -2,94 +2,79 @@ variable "bastions" { }
 variable "puppetservers" { }
 variable "terraform_data" { }
 variable "terraform_facts" { }
-variable "hieradata_folder" { }
 variable "hieradata" { }
+variable "hieradata_folder" { }
 variable "sudoer_username" { }
 variable "tf_ssh_key" { }
 variable "eyaml_key" { }
 
-data "local_file" "hieradata_yaml" {
-  for_each = var.hieradata_folder != "" ? fileset("${var.hieradata_folder}", "*.yaml") : []
-  filename = "${var.hieradata_folder}/${each.value}"
-}
-
-data "local_file" "hieradata_subfolder" {
-  for_each = var.hieradata_folder != "" ? fileset("${var.hieradata_folder}", "{prefix,hostname}/**/*.yaml") : []
-  filename = "${var.hieradata_folder}/${each.value}"
-}
-
 locals {
-  connection_parameters = length(var.bastions) > 0 ? {
+  provision_folder = "puppetserver_etc"
+}
+
+data "archive_file" "puppetserver_files" {
+  type        = "zip"
+  output_path = "${path.module}/files/${local.provision_folder}.zip"
+
+  source {
+    content  = var.terraform_data
+    filename = "${local.provision_folder}/data/terraform_data.yaml"
+  }
+
+  source {
+    content  = var.terraform_facts
+    filename = "${local.provision_folder}/facts/terraform_facts.yaml"
+  }
+
+
+  source {
+    content  = var.hieradata
+    filename = "${local.provision_folder}/data/user_data.yaml"
+  }
+
+  dynamic "source" {
+    for_each = var.hieradata_folder != "" ? fileset("${var.hieradata_folder}", "*.yaml") : []
+    iterator = filename
+    content {
+      content  = file("${var.hieradata_folder}/${filename.value}")
+      filename = "${local.provision_folder}/data/${filename.value}"
+    }
+  }
+
+  dynamic "source" {
+    for_each = var.hieradata_folder != "" ? fileset("${var.hieradata_folder}", "{prefix,hostname}/**/*.yaml") : []
+    iterator = filename
+    content {
+      content  = file("${var.hieradata_folder}/${filename.value}")
+      filename = "${local.provision_folder}/data/${filename.value}"
+    }
+  }
+
+  dynamic "source" {
+    for_each =  var.eyaml_key != "" ? [var.eyaml_key] : []
+    content {
+      content  = var.eyaml_key
+      filename = "${local.provision_folder}/puppet/eyaml/private_key.pkcs7.pem"
+    }
+  }
+}
+
+resource "terraform_data" "deploy_puppetserver_files" {
+  for_each = length(var.bastions) > 0  ? var.puppetservers : { }
+
+  connection {
+    type                = "ssh"
     bastion_host        = var.bastions[keys(var.bastions)[0]].public_ip
     bastion_user        = var.sudoer_username
     bastion_private_key = var.tf_ssh_key.private
     user                = var.sudoer_username
+    host                = each.value
     private_key         = var.tf_ssh_key.private
-  } : null
-
-  hieradata_md5 = merge(
-    {for value in data.local_file.hieradata_yaml: replace(value.filename, var.hieradata_folder, "") => value.content_md5},
-    {for value in data.local_file.hieradata_subfolder: replace(value.filename, var.hieradata_folder, "") => value.content_md5},
-  )
-  triggers_hieradata_folder = {
-    hieradata_yaml  = local.hieradata_md5
   }
 
-  triggers_hieradata = {
-    user_data      = md5(var.hieradata)
-    terraform_data = md5(var.terraform_data)
-    facts          = md5(var.terraform_facts)
+  triggers_replace = {
+    archive = data.archive_file.puppetserver_files.output_sha256
   }
-}
-
-resource "terraform_data" "deploy_hieradata_folder" {
-  for_each = local.connection_parameters != null && length(local.hieradata_md5) > 0 ? var.puppetservers : { }
-
-  connection {
-    type                = "ssh"
-    host                = each.value
-    bastion_host        = local.connection_parameters["bastion_host"]
-    bastion_user        = local.connection_parameters["bastion_user"]
-    bastion_private_key = local.connection_parameters["bastion_private_key"]
-    user                = local.connection_parameters["user"]
-    private_key         = local.connection_parameters["private_key"]
-  }
-
-  triggers_replace = local.triggers_hieradata_folder
-
-  provisioner "file" {
-    source      = "${path.cwd}/hieradata"
-    destination = "hieradata"
-  }
-
-  provisioner "remote-exec" {
-    inline = [
-      # clean up
-      "sudo rm -rf /etc/puppetlabs/data/hieradata || true",
-      "sudo mkdir -p /etc/puppetlabs/data",
-      # puppet user and group have been assigned the reserved UID/GID 52
-      "sudo cp -r hieradata /etc/puppetlabs/data/",
-      "sudo chown -R root:52 /etc/puppetlabs/data/hieradata",
-      "sudo chmod -R 650 /etc/puppetlabs/data/hieradata",
-      "rm -rf hieradata",
-    ]
-  }
-}
-
-resource "terraform_data" "deploy_hieradata" {
-  for_each = local.connection_parameters != null ? var.puppetservers : { }
-
-  connection {
-    type                = "ssh"
-    host                = each.value
-    bastion_host        = local.connection_parameters["bastion_host"]
-    bastion_user        = local.connection_parameters["bastion_user"]
-    bastion_private_key = local.connection_parameters["bastion_private_key"]
-    user                = local.connection_parameters["user"]
-    private_key         = local.connection_parameters["private_key"]
-  }
-
-  triggers_replace = local.triggers_hieradata
 
   provisioner "file" {
     source      = "${path.module}/files/${local.provision_folder}.zip"
@@ -98,41 +83,14 @@ resource "terraform_data" "deploy_hieradata" {
 
   provisioner "remote-exec" {
     inline = [
-      "sudo mkdir -p /etc/puppetlabs/data /etc/puppetlabs/facts",
-      # puppet user and group have been assigned the reserved UID/GID 52
-      "sudo install -o root -g 52 -m 640 terraform_data.yaml user_data.yaml /etc/puppetlabs/data/",
-      "sudo install -o root -g 52 -m 640 terraform_facts.yaml /etc/puppetlabs/facts/",
-      "rm -f terraform_data.yaml user_data.yaml terraform_facts.yaml",
-    ]
-  }
-}
-
-resource "terraform_data" "update_consul" {
-  for_each = local.connection_parameters != null ? var.puppetservers : { }
-
-  connection {
-    type                = "ssh"
-    host                = each.value
-    bastion_host        = local.connection_parameters["bastion_host"]
-    bastion_user        = local.connection_parameters["bastion_user"]
-    bastion_private_key = local.connection_parameters["bastion_private_key"]
-    user                = local.connection_parameters["user"]
-    private_key         = local.connection_parameters["private_key"]
-  }
-
-  triggers_replace = merge(
-    local.triggers_hieradata,
-    local.triggers_hieradata_folder,
-  )
-
-  depends_on = [
-      terraform_data.deploy_hieradata,
-      terraform_data.deploy_hieradata_folder,
-    ]
-
-  provisioner "remote-exec" {
-    inline = [
-      "[ -f /usr/local/bin/consul ] && [ -f /usr/bin/jq ] && consul event -token=$(sudo jq -r .acl.tokens.agent /etc/consul/config.json) -name=puppet $(date +%s) || true"
+      # unzip is not necessarily installed when connecting, but python is.
+      "/usr/libexec/platform-python -c 'import zipfile; zipfile.ZipFile(\"${local.provision_folder}.zip\").extractall()'",
+      "sudo chmod g-w,o-rwx $(find ${local.provision_folder}/ -type f)",
+      "sudo chown -R root:52 ${local.provision_folder}",
+      "sudo mkdir -p -m 755 /etc/puppetlabs/",
+      "sudo rsync -avh --no-t ${local.provision_folder}/ /etc/puppetlabs/",
+      "sudo rm -rf ${local.provision_folder}/ ${local.provision_folder}.zip",
+      "[ -f /usr/local/bin/consul ] && [ -f /usr/bin/jq ] && consul event -token=$(sudo jq -r .acl.tokens.agent /etc/consul/config.json) -name=puppet $(date +%s) || true",
     ]
   }
 }

--- a/common/variables.tf
+++ b/common/variables.tf
@@ -94,6 +94,12 @@ variable "hieradata" {
   }
 }
 
+variable "hieradata_folder_path" {
+  type        = string
+  default     = ""
+  description = "Path to hieradata folder containing YAML files to be included in the puppet environment"
+}
+
 variable "sudoer_username" {
   type        = string
   default     = "centos"

--- a/common/variables.tf
+++ b/common/variables.tf
@@ -94,7 +94,7 @@ variable "hieradata" {
   }
 }
 
-variable "hieradata_folder_path" {
+variable "hieradata_dir" {
   type        = string
   default     = ""
   description = "Path to hieradata folder containing YAML files to be included in the puppet environment"

--- a/common/variables.tf
+++ b/common/variables.tf
@@ -98,6 +98,10 @@ variable "hieradata_dir" {
   type        = string
   default     = ""
   description = "Path to hieradata folder containing YAML files to be included in the puppet environment"
+  validation {
+    condition     = alltrue([for filename in fileset("${var.hieradata_dir}", "**/*.yaml"): can(yamldecode(file("${var.hieradata_dir}/${filename}")))])
+    error_message = "At least one YAML file in ${var.hieradata_dir} is not a valid."
+  }
 }
 
 variable "sudoer_username" {

--- a/docs/README.md
+++ b/docs/README.md
@@ -956,6 +956,20 @@ the provided content will replace entirely the Magic Castle environment's
 **Post build modification effect**: None. To modify the Puppetfile after the cluster is initialized, log
 on the Puppet server and modify `/etc/puppetlabs/code/environments/production/Puppetfile`.
 
+### 4.20 hieradata_folder_path (optional)
+
+**Default Value:** Empty string
+
+This parameter specifies the path to a folder containing multiple YAML files used for configuring hieradata based on instance prefixes or hostnames.
+
+**Folder Structure:**
+
+- All Instances: `*.yaml`
+- Per Instance Prefix: `<prefix>/*.yaml` and `<prefix>.yaml`
+- Per Instance Hostname: `<hostname>/*.yaml` and `<hostname>.yaml`
+
+For more information on hieradata definition, refer to section [4.13 hieradata (optional)](#413-hieradata-optional).
+
 ## 5. Cloud Specific Configuration
 
 ### 5.1 Amazon Web Services

--- a/docs/README.md
+++ b/docs/README.md
@@ -958,17 +958,21 @@ on the Puppet server and modify `/etc/puppetlabs/code/environments/production/Pu
 
 ### 4.21 hieradata_dir (optional)
 
-**Default Value:** Empty string
+**default_value:** Empty string
 
-This parameter specifies the path to a folder containing multiple YAML files used for configuring hieradata based on instance prefixes or hostnames.
+Defines the path to a directory containing a hierarchy of YAML data files.
 
-**Folder Structure:**
+**Hierarchy structure:**
 
-- All Instances: `*.yaml`
-- Per Instance Prefix: `prefixes/<prefix>/*.yaml` and `prefixes/<prefix>.yaml`
-- Per Instance Hostname: `hostnames/<hostname>/*.yaml` and `hostnames/<hostname>.yaml`
+- per node hostname:
+  - `<dir>/hostnames/<hostname>/*.yaml`
+  - `<dir>/hostnames/<hostname>.yaml`
+- per node prefix:
+  - `<dir>/prefixes/<prefix>/*.yaml`
+  - `<dir>/prefixes/<prefix>.yaml`
+- all nodes: `<dir>/*.yaml`
 
-For more information on hieradata definition, refer to section [4.13 hieradata (optional)](#413-hieradata-optional).
+For more information on hieradata, refer to section [4.13 hieradata (optional)](#413-hieradata-optional).
 
 ## 5. Cloud Specific Configuration
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -783,7 +783,30 @@ The file created from this string can be found on `puppet` as
 **Post build modification effect**: trigger scp of hieradata files at next `terraform apply`.
 Each instance's Puppet agent will be reloaded following the copy of the hieradata files.
 
-### 4.14 eyaml_private (optional)
+### 4.14 hieradata_dir (optional)
+
+**default_value:** Empty string
+
+Defines the path to a directory containing a hierarchy of YAML data files.
+The hierarchy is copied on the Puppet server in `/etc/puppetlabs/data/user_data`.
+
+**Hierarchy structure:**
+
+- per node hostname:
+  - `<dir>/hostnames/<hostname>/*.yaml`
+  - `<dir>/hostnames/<hostname>.yaml`
+- per node prefix:
+  - `<dir>/prefixes/<prefix>/*.yaml`
+  - `<dir>/prefixes/<prefix>.yaml`
+- all nodes: `<dir>/*.yaml`
+
+For more information on hieradata, refer to section [4.13 hieradata (optional)](#413-hieradata-optional).
+
+**Post build modification effect**: trigger scp of hieradata files at next `terraform apply`.
+Each instance's Puppet agent will be reloaded following the copy of the hieradata files.
+
+
+### 4.15 eyaml_private (optional)
 
 **default value**: empty string
 
@@ -792,7 +815,7 @@ This key will be copied on the Puppet server.
 
 **Post build modification effect**: trigger scp of private key file at next `terraform apply`.
 
-#### 4.14.1 Generate eyaml encryption keys
+#### 4.15.1 Generate eyaml encryption keys
 
 If you plan to track the cluster configuration files in git (i.e:`main.tf`, `user_data.yaml`),
 it would be a good idea to encrypt the sensitive property values.
@@ -812,7 +835,7 @@ or with `eyaml`:
 eyaml createkeys --pkcs7-public-key=public_key.pkcs7.pem --pkcs7-private-key=private_key.pkcs7.pem
 ```
 
-#### 4.14.2 Encrypting sensitive properties
+#### 4.15.2 Encrypting sensitive properties
 
 To encrypt a sensitive property with openssl:
 ```sh
@@ -824,7 +847,7 @@ To encrypt a sensitive property with eyaml:
 eyaml encrypt -s 'your-secret' --pkcs7-public-key=public_key.pkcs7.pem -o string
 ```
 
-#### 4.14.3 Terraform cloud
+#### 4.15.3 Terraform cloud
 
 To provide the value of this variable via Terraform Cloud, encode the private key content with base64:
 
@@ -852,7 +875,7 @@ module "openstack" {
 }
 ```
 
-### 4.15 firewall_rules (optional)
+### 4.16 firewall_rules (optional)
 
 **default value**:
 ```hcl
@@ -886,7 +909,7 @@ about this requirement, refer to Magic Castle's
 
 **Post build modification effect**: modify the cloud provider firewall rules at next `terraform apply`.
 
-### 4.16 generate_ssh_key (optional)
+### 4.17 generate_ssh_key (optional)
 
 **default_value**: `false`
 
@@ -907,7 +930,7 @@ next terraform apply. The Terraform public SSH key will be removed
 from the sudoer account `authorized_keys` file at next
 Puppet agent run.
 
-### 4.17 software_stack (optional)
+### 4.18 software_stack (optional)
 
 **default_value**: `"alliance"`
 
@@ -920,7 +943,7 @@ Possible values are:
 
 **Post build modification effect**: trigger scp of hieradata files at next `terraform apply`.
 
-### 4.18 pool (optional)
+### 4.19 pool (optional)
 
 **default_value**: `[]`
 
@@ -932,7 +955,7 @@ managed by the workload scheduler through Terraform API. For more information, r
 will be instantiated, others will stay uninstantiated or will be destroyed
 if previously instantiated.
 
-### 4.19 skip_upgrade (optional)
+### 4.20 skip_upgrade (optional)
 
 **default_value** = `false`
 
@@ -943,7 +966,7 @@ all packages are upgraded.
 after the modification will take into consideration the new value of the parameter to determine
 whether they should upgrade the base image packages or not.
 
-### 4.20 puppetfile (optional)
+### 4.21 puppetfile (optional)
 
 **default_value** = `""`
 
@@ -955,24 +978,6 @@ the provided content will replace entirely the Magic Castle environment's
 
 **Post build modification effect**: None. To modify the Puppetfile after the cluster is initialized, log
 on the Puppet server and modify `/etc/puppetlabs/code/environments/production/Puppetfile`.
-
-### 4.21 hieradata_dir (optional)
-
-**default_value:** Empty string
-
-Defines the path to a directory containing a hierarchy of YAML data files.
-
-**Hierarchy structure:**
-
-- per node hostname:
-  - `<dir>/hostnames/<hostname>/*.yaml`
-  - `<dir>/hostnames/<hostname>.yaml`
-- per node prefix:
-  - `<dir>/prefixes/<prefix>/*.yaml`
-  - `<dir>/prefixes/<prefix>.yaml`
-- all nodes: `<dir>/*.yaml`
-
-For more information on hieradata, refer to section [4.13 hieradata (optional)](#413-hieradata-optional).
 
 ## 5. Cloud Specific Configuration
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -956,7 +956,7 @@ the provided content will replace entirely the Magic Castle environment's
 **Post build modification effect**: None. To modify the Puppetfile after the cluster is initialized, log
 on the Puppet server and modify `/etc/puppetlabs/code/environments/production/Puppetfile`.
 
-### 4.20 hieradata_dir (optional)
+### 4.21 hieradata_dir (optional)
 
 **Default Value:** Empty string
 
@@ -965,8 +965,8 @@ This parameter specifies the path to a folder containing multiple YAML files use
 **Folder Structure:**
 
 - All Instances: `*.yaml`
-- Per Instance Prefix: `<prefix>/*.yaml` and `<prefix>.yaml`
-- Per Instance Hostname: `<hostname>/*.yaml` and `<hostname>.yaml`
+- Per Instance Prefix: `prefixes/<prefix>/*.yaml` and `prefixes/<prefix>.yaml`
+- Per Instance Hostname: `hostnames/<hostname>/*.yaml` and `hostnames/<hostname>.yaml`
 
 For more information on hieradata definition, refer to section [4.13 hieradata (optional)](#413-hieradata-optional).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -956,7 +956,7 @@ the provided content will replace entirely the Magic Castle environment's
 **Post build modification effect**: None. To modify the Puppetfile after the cluster is initialized, log
 on the Puppet server and modify `/etc/puppetlabs/code/environments/production/Puppetfile`.
 
-### 4.20 hieradata_folder_path (optional)
+### 4.20 hieradata_dir (optional)
 
 **Default Value:** Empty string
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -772,11 +772,7 @@ Refer to the following Puppet modules' documentation to know more about the key-
 - [puppet-jupyterhub](https://github.com/ComputeCanada/puppet-jupyterhub/blob/main/README.md#hieradata-configuration)
 - [puppet-prometheus](https://forge.puppet.com/modules/puppet/prometheus/)
 
-
-The file created from this string can be found on `puppet` as
-```
-/etc/puppetlabs/data/user_data.yaml
-```
+The file created from this string can be found on the Puppet server as `/etc/puppetlabs/data/user_data.yaml`
 
 **Requirement**: The string needs to respect the [YAML syntax](https://en.wikipedia.org/wiki/YAML#Syntax).
 

--- a/gcp/infrastructure.tf
+++ b/gcp/infrastructure.tf
@@ -42,6 +42,7 @@ module "provision" {
   terraform_data  = module.configuration.terraform_data
   terraform_facts = module.configuration.terraform_facts
   hieradata       = var.hieradata
+  hieradata_folder = var.hieradata_folder_path
   sudoer_username = var.sudoer_username
   eyaml_key       = var.eyaml_key
   depends_on      = [ google_compute_instance.instances ]

--- a/gcp/infrastructure.tf
+++ b/gcp/infrastructure.tf
@@ -42,7 +42,7 @@ module "provision" {
   terraform_data  = module.configuration.terraform_data
   terraform_facts = module.configuration.terraform_facts
   hieradata       = var.hieradata
-  hieradata_folder = var.hieradata_folder_path
+  hieradata_dir   = var.hieradata_dir
   sudoer_username = var.sudoer_username
   eyaml_key       = var.eyaml_key
   depends_on      = [ google_compute_instance.instances ]

--- a/openstack/infrastructure.tf
+++ b/openstack/infrastructure.tf
@@ -37,7 +37,7 @@ module "provision" {
   terraform_data  = module.configuration.terraform_data
   terraform_facts = module.configuration.terraform_facts
   hieradata       = var.hieradata
-  hieradata_folder = var.hieradata_folder_path
+  hieradata_dir   = var.hieradata_dir
   sudoer_username = var.sudoer_username
   eyaml_key       = var.eyaml_key
   depends_on      = [

--- a/openstack/infrastructure.tf
+++ b/openstack/infrastructure.tf
@@ -37,6 +37,7 @@ module "provision" {
   terraform_data  = module.configuration.terraform_data
   terraform_facts = module.configuration.terraform_facts
   hieradata       = var.hieradata
+  hieradata_folder = var.hieradata_folder_path
   sudoer_username = var.sudoer_username
   eyaml_key       = var.eyaml_key
   depends_on      = [


### PR DESCRIPTION
Close #287 

This PR allows for setting custom hieradata per group of instances sharing the same prefix.

It works by setting a new `prefix` fact on each instance. Then, all prefix hieradata are gathered in one file (`prefix.yaml`) and copied to `mgmt`. The hieradata are mapped based on the prefix and parsed accordingly by Puppet.

This approach differs from the task definition in the issue. Initially, the idea was to copy one file per prefix, but [Terraform provisioners don't support dynamic](https://github.com/hashicorp/terraform/issues/30225), and the number of files is only known at runtime.

See https://github.com/ComputeCanada/puppet-magic_castle/pull/324 for puppet logic
