### PR TITLE
Remove efa driver installation from cloud-init (use puppet installation instead)

### DIFF
--- a/common/configuration/puppet.yaml
+++ b/common/configuration/puppet.yaml
@@ -110,12 +110,6 @@ runcmd:
   - systemctl enable puppet
 # Remove all ifcfg configuration files that have no corresponding network interface in ip link show.
   - for i in /etc/sysconfig/network-scripts/ifcfg-*; do if ! ip link show | grep -q "$${i##*-}:"; then rm -f $i; fi; done
-# AWS EFA driver installation
-%{ if contains(tags, "efa") }
-  - curl -O https://efa-installer.amazonaws.com/aws-efa-installer-latest.tar.gz
-  - "(tar xf aws-efa-installer-latest.tar.gz && cd aws-efa-installer && ./efa_installer.sh --yes --minimal)"
-  - rm -fr aws-efa-installer aws-efa-installer-latest.tar.gz
-%{ endif }
 %{ if cloud_provider == "gcp" }
 # Google Cloud user-data fact generates a warning because its size is greater than what is allowed (<4096 bytes).
 # We have no use for it, so we remove startup-script, user-data and user-data-encoding when running in GCE.


### PR DESCRIPTION
Depends https://github.com/ComputeCanada/puppet-magic_castle/pull/331

This PR should be merge after the puppet one otherwise it will break EFA installation. 