### PR TITLE
Change permissions to /var/log/cloud-init.log

### DIFF
--- a/common/configuration/puppet.yaml
+++ b/common/configuration/puppet.yaml
@@ -197,3 +197,6 @@ power_state:
   delay: now
   mode: reboot
   condition: test ! -f /etc/magic-castle-release
+
+# Change permissions to $def_log_file
+syslog_fix_perms: root:systemd-journal

--- a/common/configuration/puppet.yaml
+++ b/common/configuration/puppet.yaml
@@ -198,5 +198,5 @@ power_state:
   mode: reboot
   condition: test ! -f /etc/magic-castle-release
 
-# Change permissions to $def_log_file
+# Configure owner of /var/log/cloud-init.log
 syslog_fix_perms: root:systemd-journal


### PR DESCRIPTION
I was initially tying to add DEBUG log to journald. The logging is define by this [file](https://github.com/canonical/cloud-init/blob/90c15a60fbf035a9fbc2341834e1d6096e7889a9/config/cloud.cfg.d/05_logging.cfg#L60) and support sending log to `/dev/log` by default. Setting `log_cfgs: [ "*log_base", "*log_file", "*log_syslog" ]` will add the DEBUG log in journald, but unfortunately, it only apply after the first reboot. It would not work with the "mcspeed" project.

Instead, there is a parameter to change the log file permissions. I set the group to `systemd-journal` and should be accessible by vector.