### PR TITLE
Refactor SSHFP record generation removing hardcoded algorithm names

### DIFF
--- a/dns/record_generator/key2fp.py
+++ b/dns/record_generator/key2fp.py
@@ -1,15 +1,21 @@
 #!/usr/bin/env python3
+"""
+Generate SSHFP fingerprint dictionary where:
+- key correspond to SSHFP algorithm i.e: ssh-...
+- value corresponds to SHA256 fingerprint of the hostkey
+
+Terraform external data source can only output map (dict)
+where both keys and values can only be string.
+
+This external data source is required because the latest available release of
+Terraform (1.8.2) can only process UTF-8 strings when decoding base64 and computing
+sha256 checksums. SSH hostkeys are base64 encoded bytes, therefore trying to
+decode them directly with Terraform functions fail.
+"""
 import base64
 import hashlib
 import json
 import sys
-
-ALGORITHMS = {
-    'ssh-rsa' : '1',
-    'ssh-dss' : '2',
-    'ssh-ecdsa' : '3',
-    'ssh-ed25519' : '4'
-}
 
 outputs = {}
 
@@ -18,10 +24,7 @@ inputs = json.load(sys.stdin)
 for alg, ssh_key in inputs.items():
     key_type, key = ssh_key.split()
     key_bytes = base64.b64decode(key)
-    alg_index = ALGORITHMS[key_type]
     fp_sha256 = hashlib.sha256(key_bytes).hexdigest()
-
-    outputs['{alg}_algorithm'.format(alg=alg)] = alg_index
-    outputs['{alg}_sha256'.format(alg=alg)] = fp_sha256
+    outputs[key_type] = fp_sha256
 
 print(json.dumps(outputs))


### PR DESCRIPTION
We loop on the hostkeys to register the corresponding SSHFP. We thought of looping on the data sources, but this trigger an error because Terraform is unable to predict how many elements will be present in the map output by the key2fp datasource. While we know it will corresponds to the number of hostkeys, Terraform does not, and there is no way to tell it. So instead, we loop on the hostkey and recover the algorithm index locally.

This PR also fixes issue #214.