### PR TITLE
Update cloudflare record to support >=v4.39.0

### DIFF
--- a/dns/cloudflare/main.tf
+++ b/dns/cloudflare/main.tf
@@ -11,8 +11,8 @@ data "cloudflare_zones" "domain" {
 }
 
 module "record_generator" {
-  source         = "../record_generator"
-  name           = lower(var.name)
+  source           = "../record_generator"
+  name             = lower(var.name)
   public_instances = var.public_instances
   vhosts           = var.vhosts
   domain_tag       = var.domain_tag
@@ -23,7 +23,7 @@ resource "cloudflare_record" "records" {
   count   = length(module.record_generator.records)
   zone_id = data.cloudflare_zones.domain.zones[0].id
   name    = module.record_generator.records[count.index].name
-  value   = module.record_generator.records[count.index].value
+  content = module.record_generator.records[count.index].value
   type    = module.record_generator.records[count.index].type
   dynamic "data" {
     for_each = module.record_generator.records[count.index].data != null ? [module.record_generator.records[count.index].data] : []
@@ -51,5 +51,5 @@ module "acme" {
 }
 
 output "hostnames" {
-  value = distinct(compact([for record in module.record_generator.records : join(".", [record.name, var.domain]) if record.type == "A" ]))
+  value = distinct(compact([for record in module.record_generator.records : join(".", [record.name, var.domain]) if record.type == "A"]))
 }

--- a/dns/cloudflare/versions.tf
+++ b/dns/cloudflare/versions.tf
@@ -3,7 +3,8 @@ terraform {
   required_version = ">= 1.4.0"
   required_providers {
     cloudflare = {
-      source = "cloudflare/cloudflare"
+      source  = "cloudflare/cloudflare"
+      version = ">= 4.39.0"
     }
     acme = {
       source = "vancluever/acme"


### PR DESCRIPTION
The `value` field in the `cloudflare_record` is deprecated and stop working in v4.39.0 of Cloudflare terraform provider: https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/record#value

From what I understand, this version was not suppose to stop supporting this field and can be considered a bug in the provider. But we should still switch to `content` because `value` is deprecated.