### PR TITLE
Fix terraform lock file in release 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 1.2.1
+          terraform_version: 1.9.5
 
       - name: Create tarballs and zips
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 1.9.5
+          terraform_version: 1.4.0
 
       - name: Create tarballs and zips
         if: startsWith(github.ref, 'refs/tags/')

--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 VERSION=$1
 shift
 CLOUD=($@)


### PR DESCRIPTION
close #319 

The file was not generated because the `terraform init` was failing due to minimum terraform version required. The CI was not falling on this error so, I added `set -e` to avoid the same issue in the future.

Should we set the terraform to latest in the CI? 