### PR TITLE
Add admin_ssh_key to ignore_changes list in Azure

### DIFF
--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -110,7 +110,6 @@ resource "azurerm_linux_virtual_machine" "instances" {
       username   = "azure"
       public_key = key.value
     }
-
   }
 
   priority = contains(each.value["tags"], "spot") ? "Spot" : "Regular"
@@ -123,6 +122,7 @@ resource "azurerm_linux_virtual_machine" "instances" {
       source_image_reference,
       source_image_id,
       custom_data,
+      admin_ssh_key,
     ]
   }
 }


### PR DESCRIPTION
Magic Castle documentation states the public_keys can be changed without impact on the cluster. For Azure, it was false as any change to public_keys would trigger a rebuild of all instances.