### PR TITLE
Split sshd config so that Match directives are in their own files

### DIFF
--- a/common/configuration/puppet.yaml
+++ b/common/configuration/puppet.yaml
@@ -135,9 +135,9 @@ write_files:
     path: /etc/ssh/authorized_keys.tf
     permissions: "0644"
   - content: |
-    Match User tf
-      AuthorizedKeysFile /etc/ssh/authorized_keys.%u
-      AuthenticationMethods publickey
+      Match User tf
+        AuthorizedKeysFile /etc/ssh/authorized_keys.%u
+        AuthenticationMethods publickey
     path: /etc/ssh/sshd_config.d/50-authenticationmethods.conf
     permissions: "0600"
   - content: |

--- a/common/configuration/puppet.yaml
+++ b/common/configuration/puppet.yaml
@@ -27,7 +27,7 @@ runcmd:
   - chmod 755 /etc # avoid issue with Rocky 9.4
   - test ! -d /${sudoer_username} && userdel -f -r ${sudoer_username} && cloud-init clean -r
   - restorecon -R /${sudoer_username}
-  - echo -e "match User tf\n\tAuthorizedKeysFile /etc/ssh/authorized_keys.%u\n\tAuthenticationMethods publickey" >> /etc/ssh/sshd_config
+  - echo -e "Include /etc/ssh/sshd_config.d/50-authenticationmethods.conf" >> /etc/ssh/sshd_config
   - sed -i '/HostKey \/etc\/ssh\/ssh_host_ecdsa_key/ s/^#*/#/' /etc/ssh/sshd_config
   - chmod 644 /etc/ssh/ssh_host_*_key.pub
   - chgrp ssh_keys /etc/ssh/ssh_host_*_key.pub
@@ -134,6 +134,12 @@ write_files:
   - content: restrict%{ if contains(tags, "puppet") },pty%{ else }%{ for host, ip in puppetservers },permitopen="${ip}:22"%{ endfor },port-forwarding,command="/sbin/nologin"%{ endif } ${tf_ssh_public_key}
     path: /etc/ssh/authorized_keys.tf
     permissions: "0644"
+  - content: |
+    Match User tf
+      AuthorizedKeysFile /etc/ssh/authorized_keys.%u
+      AuthenticationMethods publickey
+    path: /etc/ssh/sshd_config.d/50-authenticationmethods.conf
+    permissions: "0600"
   - content: |
       facts : {
         blocklist : [

--- a/common/configuration/puppet.yaml
+++ b/common/configuration/puppet.yaml
@@ -27,7 +27,7 @@ runcmd:
   - chmod 755 /etc # avoid issue with Rocky 9.4
   - test ! -d /${sudoer_username} && userdel -f -r ${sudoer_username} && cloud-init clean -r
   - restorecon -R /${sudoer_username}
-  - echo -e "match User tf\n\tAuthorizedKeysFile /etc/ssh/authorized_keys.%u\n\tAuthenticationMethods publickey" >> /etc/ssh/sshd_config
+  - echo -e "Include /etc/ssh/sshd_config.d/50-authenticationmethods.conf" >> /etc/ssh/sshd_config
   - sed -i '/HostKey \/etc\/ssh\/ssh_host_ecdsa_key/ s/^#*/#/' /etc/ssh/sshd_config
   - chmod 644 /etc/ssh/ssh_host_*_key.pub
   - chgrp ssh_keys /etc/ssh/ssh_host_*_key.pub

--- a/common/configuration/puppet.yaml
+++ b/common/configuration/puppet.yaml
@@ -27,7 +27,7 @@ runcmd:
   - chmod 755 /etc # avoid issue with Rocky 9.4
   - test ! -d /${sudoer_username} && userdel -f -r ${sudoer_username} && cloud-init clean -r
   - restorecon -R /${sudoer_username}
-  - echo -e "Include /etc/ssh/sshd_config.d/50-authenticationmethods.conf" >> /etc/ssh/sshd_config
+  - echo -e "match User tf\n\tAuthorizedKeysFile /etc/ssh/authorized_keys.%u\n\tAuthenticationMethods publickey" >> /etc/ssh/sshd_config
   - sed -i '/HostKey \/etc\/ssh\/ssh_host_ecdsa_key/ s/^#*/#/' /etc/ssh/sshd_config
   - chmod 644 /etc/ssh/ssh_host_*_key.pub
   - chgrp ssh_keys /etc/ssh/ssh_host_*_key.pub


### PR DESCRIPTION
This is to avoid issues with other puppet modules, such as duo-unix, which use augeas to configure sshd. augeas has issues when trying to add new directives if there are Match directives in the sshd_config file. 

This goes hand in hand with PR https://github.com/ComputeCanada/puppet-magic_castle/pull/416