### PR TITLE
Replace list of specific subdomains by *

### DIFF
--- a/dns/cloudflare/variables.tf
+++ b/dns/cloudflare/variables.tf
@@ -7,7 +7,7 @@ variable "domain" {
 variable "vhosts" {
   description = "List of vhost dns records to create as vhost.name.domain_name."
   type    = list(string)
-  default = ["ipa", "jupyter", "mokey", "explore"]
+  default = ["*"]
 }
 
 variable "domain_tag" {


### PR DESCRIPTION
This leaves the ability to explictly specify the A records, but by default all traffic that falls in the wild card will now be directed to reverse proxy.