### PR TITLE
Do not attempt to validate yaml templates inside of .terraform folder

### DIFF
--- a/common/variables.tf
+++ b/common/variables.tf
@@ -99,7 +99,7 @@ variable "hieradata_dir" {
   default     = ""
   description = "Path to hieradata folder containing YAML files to be included in the puppet environment"
   validation {
-    condition     = var.hieradata_dir == "" || alltrue([for filename in fileset("${var.hieradata_dir}", "**/*.yaml"): can(yamldecode(file("${var.hieradata_dir}/${filename}")))])
+    condition     = var.hieradata_dir == "" || alltrue([for filename in setsubtract(fileset("${var.hieradata_dir}", "**/*.yaml"), fileset("${var.hieradata_dir}", ".terraform/**/*.yaml")): can(yamldecode(file("${var.hieradata_dir}/${filename}")))])
     error_message = "At least one YAML file in ${var.hieradata_dir} is not a valid."
   }
 }


### PR DESCRIPTION
`.terraform` folder contains template yaml files, which fail to validate when `hieradata_dir = './'` 

This excludes them from validation. 

Was tested on https://github.com/calculquebec/magic_clusters/tree/next