### PR TITLE
Replace puppetlabs-puppet by OpenVox

### DIFF
--- a/common/configuration/puppet.yaml.tftpl
+++ b/common/configuration/puppet.yaml.tftpl
@@ -60,12 +60,12 @@ runcmd:
       dnf -y install git pciutils unzip
       dnf -y remove cockpit\* firewalld --exclude=iptables
 %{ if ! skip_upgrade ~}
-      # Upgrade all packages except Puppet if already installed
-      dnf -y upgrade -x puppet*
+      # Upgrade all packages except openvox if already installed
+      dnf -y upgrade -x openvox*
 %{ endif ~}
       # Puppet agent configuration and install
-      dnf -y install https://yum.puppet.com/puppet7-release-el-$(grep -oP 'VERSION_ID="\K[^"]' /etc/os-release).noarch.rpm
-      dnf -y install puppet-agent-7.32.1
+      dnf -y install https://yum.voxpupuli.org/openvox7-release-el-$(grep -oP 'VERSION_ID="\K[^"]' /etc/os-release).noarch.rpm
+      dnf -y install openvox-agent-7.37.2
       install -m 700 /dev/null /opt/puppetlabs/bin/postrun
       # kernel configuration
       systemctl disable kdump
@@ -73,10 +73,8 @@ runcmd:
       grub2-mkconfig -o /boot/grub2/grub.cfg
     fi
 %{ if contains(tags, "puppet") }
-# Install Java 11 and puppetserver
-  - dnf -y install java-11-openjdk-headless puppetserver-7.17.2
-# Configure puppetserver to use Java 11
-  - sudo sed -i 's;\(JAVA_BIN=\).*;\1"/usr/lib/jvm/jre-11/bin/java";g' /etc/sysconfig/puppetserver
+# Install puppetserver
+  - dnf -y install openvox-server-7.18.2
 # Configure puppet-agent to start after puppetserver when on puppetserver
   - sed -i 's/^\(After=.*\)$/\1 puppetserver.service/' /usr/lib/systemd/system/puppet.service
   - systemctl daemon-reload


### PR DESCRIPTION
> OpenVox started life as a Puppet™️ mirror by [Overlook InfraTech](https://overlookinfratech.com/downloads/) to continue providing community packages when Perforce discontinued public packaging efforts in late Fall of 2024.

https://voxpupuli.org/openvox/