### PR TITLE
Fixes to be able to complete the puppet installation and configuration with EL10 images

### DIFF
--- a/common/configuration/puppet.yaml.tftpl
+++ b/common/configuration/puppet.yaml.tftpl
@@ -35,6 +35,11 @@ runcmd:
     # most container images do not have selinux pre-installed
   - restorecon -R /${sudoer_username}
 %{ endif }
+  # If the image has not openssh-server installed but sshd_config still exists
+  # installing the new RPM will not overwrite the file and depending on the file
+  # content it might catastrophic (some sshd_config are empty, some miss esential lines).
+  # Therefore when openssh-server is not installed, we remove sshd_config before installing it.
+  - "[ -z $(rpm -qa openssh-server) ] && rm -f /etc/ssh/sshd_config"
   - dnf -y install openssh openssh-server rsync
   - echo -e "Include /etc/ssh/sshd_config.d/50-authenticationmethods.conf" >> /etc/ssh/sshd_config
   - sed -i '/HostKey \/etc\/ssh\/ssh_host_ecdsa_key/ s/^#*/#/' /etc/ssh/sshd_config

--- a/common/configuration/puppet.yaml.tftpl
+++ b/common/configuration/puppet.yaml.tftpl
@@ -64,7 +64,7 @@ runcmd:
       dnf -y upgrade -x openvox*
 %{ endif ~}
       # Puppet agent configuration and install
-      dnf -y install https://yum.voxpupuli.org/openvox8-release-el-$(grep -oP 'VERSION_ID="\K[^"]' /etc/os-release).noarch.rpm
+      dnf -y install https://yum.voxpupuli.org/openvox8-release-el-$(grep -oP 'VERSION_ID="\K\d*' /etc/os-release).noarch.rpm
       dnf -y install openvox-agent-8.19.2
       install -m 700 /dev/null /opt/puppetlabs/bin/postrun
       # kernel configuration

--- a/common/configuration/puppet.yaml.tftpl
+++ b/common/configuration/puppet.yaml.tftpl
@@ -65,7 +65,7 @@ runcmd:
 %{ endif ~}
       # Puppet agent configuration and install
       dnf -y install https://yum.voxpupuli.org/openvox8-release-el-$(grep -oP 'VERSION_ID="\K\d*' /etc/os-release).noarch.rpm
-      dnf -y install openvox-agent-8.19.2
+      dnf -y install openvox-agent-8.23.1
       install -m 700 /dev/null /opt/puppetlabs/bin/postrun
       # kernel configuration
       systemctl disable kdump
@@ -74,7 +74,7 @@ runcmd:
     fi
 %{ if contains(tags, "puppet") }
 # Install puppetserver
-  - dnf -y install openvox-server-8.8.1
+  - dnf -y install openvox-server-8.11.0
 # Configure puppet-agent to start after puppetserver when on puppetserver
   - sed -i 's/^\(After=.*\)$/\1 puppetserver.service/' /usr/lib/systemd/system/puppet.service
   - systemctl daemon-reload


### PR DESCRIPTION
A few things were broken:
- The regex to retrieve the OS major version was working for only one digit.
- Bump the openvox server version. Previous version depended on an java rpm that is no available in EL10.
- Incus image for Rocky and AlmaLinux 10 come with `/etc/sshd/sshd_config` even if openssh-server is not installed. It needs to be deleted before installing the rpm otherwise sshd config is broken.