### PR TITLE
Move dnf commands and ssh config under test magic-castle-release

### DIFF
--- a/common/configuration/puppet.yaml.tftpl
+++ b/common/configuration/puppet.yaml.tftpl
@@ -35,17 +35,6 @@ runcmd:
     # most container images do not have selinux pre-installed
   - restorecon -R /${sudoer_username}
 %{ endif }
-  # If the image has not openssh-server installed but sshd_config still exists
-  # installing the new RPM will not overwrite the file and depending on the file
-  # content it might catastrophic (some sshd_config are empty, some miss esential lines).
-  # Therefore when openssh-server is not installed, we remove sshd_config before installing it.
-  - "[ -z $(rpm -qa openssh-server) ] && rm -f /etc/ssh/sshd_config"
-  - dnf -y install openssh openssh-server rsync
-  - echo -e "Include /etc/ssh/sshd_config.d/50-authenticationmethods.conf" >> /etc/ssh/sshd_config
-  - sed -i '/HostKey \/etc\/ssh\/ssh_host_ecdsa_key/ s/^#*/#/' /etc/ssh/sshd_config
-  - chmod 644 /etc/ssh/ssh_host_*_key.pub
-  - chgrp ssh_keys /etc/ssh/ssh_host_*_key.pub
-  - systemctl restart sshd
 # Make sure puppet server can be reached by name early in the process if we need to debug.
 # For some provider, the ip address of the puppetserver is not known in advance, so we make
 # sure it is not empty before adding it to /etc/hosts
@@ -54,11 +43,22 @@ runcmd:
   - echo "${ip} ${host}" >> /etc/hosts
 %{ endif ~}
 %{ endfor ~}
-  # Enable fastest mirror for distribution using dnf package manager
-  - dnf config-manager --setopt=fastestmirror=True --save
   # Install package and configure kernel only if building from a "vanilla" linux image
   - |
     if ! test -f /etc/magic-castle-release; then
+      # Enable fastest mirror for distribution using dnf package manager
+      dnf config-manager --setopt=fastestmirror=True --save
+      # If the image has not openssh-server installed but sshd_config still exists
+      # installing the new RPM will not overwrite the file and depending on the file
+      # content it might catastrophic (some sshd_config are empty, some miss esential lines).
+      # Therefore when openssh-server is not installed, we remove sshd_config before installing it.
+      "[ -z $(rpm -qa openssh-server) ] && rm -f /etc/ssh/sshd_config"
+      dnf -y install openssh openssh-server rsync
+      echo -e "Include /etc/ssh/sshd_config.d/50-authenticationmethods.conf" >> /etc/ssh/sshd_config
+      sed -i '/HostKey \/etc\/ssh\/ssh_host_ecdsa_key/ s/^#*/#/' /etc/ssh/sshd_config
+      chmod 644 /etc/ssh/ssh_host_*_key.pub
+      chgrp ssh_keys /etc/ssh/ssh_host_*_key.pub
+      systemctl restart sshd
       # Install required packages in runcmd instead of packages to speedup configuration
       # of the admin user. This reduces the risk of Terraform timing out when trying to
       # upload the terraform_data.yaml


### PR DESCRIPTION
These commands do not need to be executed again after initial config, and we can improve slightly the boot time from snapshot when first looking if the image as already been previously configured by Magic Castle.