### PR TITLE
Add az_metadata, cloud.provider and hypervisor to facter blocklist

### DIFF
--- a/common/configuration/puppet.yaml.tftpl
+++ b/common/configuration/puppet.yaml.tftpl
@@ -162,8 +162,8 @@ write_files:
   - content: |
       facts : {
         blocklist : [
-          "EC2",
-          %{ if cloud_provider != "gcp" } "GCE", %{ endif }
+          "EC2", "az_metadata", "cloud.provider", "hypervisors"
+          %{ if cloud_provider != "gcp" },"GCE",%{ endif }
         ],
       }
     path: /etc/puppetlabs/facter/facter.conf


### PR DESCRIPTION
We rely on our own static fact file to determine the cloud provider and these facts we add to the blocklist take a long time to resolve.