### PR TITLE
Add support for GPU in Incus

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -618,7 +618,7 @@ available models per region
 ##### Incus
 
 - `target`: name of the [specific cluster member](https://linuxcontainers.org/incus/docs/main/howto/cluster_manage_instance/#launch-an-instance-on-a-specific-cluster-member) to deploy the instance. **Only use with Incus cluster.** 
-* `gpus_pci`: list of [PCI addresses of the GPU devices](https://linuxcontainers.org/incus/docs/main/reference/devices_gpu/#devices-gpu_physical:pci) to pass through to instances on the node. The node `count` **must be 1**. Use `incus info --resources` to list available resources.
+* `gpus_pci`: list of [PCI addresses of the GPU devices](https://linuxcontainers.org/incus/docs/main/reference/devices_gpu/#devices-gpu_physical:pci) to pass through to instances on the node. Use `incus info --resources` to list available resources. **Limitation:** The node `count` **must be 1** and the container **must be unprivileged**.
 
 #### 4.7.3 Post build modification effect
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -618,7 +618,12 @@ available models per region
 ##### Incus
 
 - `target`: name of the [specific cluster member](https://linuxcontainers.org/incus/docs/main/howto/cluster_manage_instance/#launch-an-instance-on-a-specific-cluster-member) to deploy the instance. **Only use with Incus cluster.** 
-* `gpus_pci`: list of [PCI addresses of the GPU devices](https://linuxcontainers.org/incus/docs/main/reference/devices_gpu/#devices-gpu_physical:pci) to pass through to instances on the node. Use `incus info --resources` to list available resources. The Incus host must have the NVIDIA GPU driver and the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#with-dnf-rhel-centos-fedora-amazon-linux) installed. **Limitations:** the node `count` **must be 1** and the container **must be unprivileged**.
+* `gpus_pci`: list of [PCI addresses of the GPU devices](https://linuxcontainers.org/incus/docs/main/reference/devices_gpu/#devices-gpu_physical:pci) to pass through to instances on the node. Use `incus info --resources` to list available resources. The Incus host must have the NVIDIA GPU driver and the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#with-dnf-rhel-centos-fedora-amazon-linux) installed. ***
+
+**Limitations:**
+ * The node `count` **must be 1** 
+ * The container **must be unprivileged**
+ * **Do not use the `gpu` tag**, as it would install the NVIDIA driver. We use the host’s driver instead.
 
 
 #### 4.7.3 Post build modification effect

--- a/docs/README.md
+++ b/docs/README.md
@@ -618,6 +618,7 @@ available models per region
 ##### Incus
 
 - `target`: name of the [specific cluster member](https://linuxcontainers.org/incus/docs/main/howto/cluster_manage_instance/#launch-an-instance-on-a-specific-cluster-member) to deploy the instance. **Only use with Incus cluster.** 
+* `gpus_pci`: list of [PCI addresses of the GPU devices](https://linuxcontainers.org/incus/docs/main/reference/devices_gpu/#devices-gpu_physical:pci) to pass through to instances on the node. The node `count` **must be 1**. Use `incus info --resources` to list available resources.
 
 #### 4.7.3 Post build modification effect
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -618,7 +618,8 @@ available models per region
 ##### Incus
 
 - `target`: name of the [specific cluster member](https://linuxcontainers.org/incus/docs/main/howto/cluster_manage_instance/#launch-an-instance-on-a-specific-cluster-member) to deploy the instance. **Only use with Incus cluster.** 
-* `gpus_pci`: list of [PCI addresses of the GPU devices](https://linuxcontainers.org/incus/docs/main/reference/devices_gpu/#devices-gpu_physical:pci) to pass through to instances on the node. Use `incus info --resources` to list available resources. **Limitation:** The node `count` **must be 1** and the container **must be unprivileged**.
+* `gpus_pci`: list of [PCI addresses of the GPU devices](https://linuxcontainers.org/incus/docs/main/reference/devices_gpu/#devices-gpu_physical:pci) to pass through to instances on the node. Use `incus info --resources` to list available resources. The Incus host must have the NVIDIA GPU driver and the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#with-dnf-rhel-centos-fedora-amazon-linux) installed. **Limitations:** the node `count` **must be 1** and the container **must be unprivileged**.
+
 
 #### 4.7.3 Post build modification effect
 

--- a/examples/incus/main.tf
+++ b/examples/incus/main.tf
@@ -15,6 +15,8 @@ module "incus" {
     mgmt  = { type = "container", cpus = 4, ram = 6000, gpus = 0, tags = ["puppet", "mgmt", "nfs"], count = 1 }
     login = { type = "container", cpus = 2, ram = 3000, gpus = 0, tags = ["login", "proxy"], count = 1 }
     node  = { type = "container", cpus = 2, ram = 3000, gpus = 0, tags = ["node"], count = 1 }
+    # Uncomment the folowing line to mount a GPU. The PCI id must match with the GPU and the container must be unprivileged
+    # node_gpu = { type = "container", cpus = 2, ram = 3000, gpus = 0, tags = ["node"], count = 1, gpu_pci = ["0000:00:06.0"] }
   }
 
   firewall_rules = {

--- a/examples/incus/main.tf
+++ b/examples/incus/main.tf
@@ -16,6 +16,7 @@ module "incus" {
     login = { type = "container", cpus = 2, ram = 3000, gpus = 0, tags = ["login", "proxy"], count = 1 }
     node  = { type = "container", cpus = 2, ram = 3000, gpus = 0, tags = ["node"], count = 1 }
     # Uncomment the folowing line to mount a GPU. The PCI id must match with the GPU and the container must be unprivileged
+    # Do not use the gpu tag, as it would install the NVIDIA driver. We use the host’s driver instead.
     # node_gpu = { type = "container", cpus = 2, ram = 3000, gpus = 0, tags = ["node"], count = 1, gpu_pci = ["0000:00:06.0"] }
   }
 

--- a/examples/incus/unprivileged.yaml
+++ b/examples/incus/unprivileged.yaml
@@ -6,6 +6,9 @@ lookup_options:
 
 jupyterhub::kernel::venv::python: "3.12"
 
+profile::cvmfs::local_user::uid: 40001
+profile::cvmfs::local_user::gid: 40001
+
 magic_castle::site::all:
   - profile::base
   - profile::consul


### PR DESCRIPTION
Add support for GPUs in Incus by explicitly passing the PCI IDs of the GPU devices as a list.

This has multiple limitations:
1. The NVIDIA driver and the NVIDIA Container Toolkit must be installed on the Incus host.
2. It only works with unprivileged containers (there is a validation in the code for this).
3. The node `count` must be 1 (no validation is currently enforced).