### PR TITLE
Enable incus security.nesting when privileged is enabled

### DIFF
--- a/incus/infrastructure.tf
+++ b/incus/infrastructure.tf
@@ -91,6 +91,7 @@ resource "incus_instance" "instances" {
   config = {
     "cloud-init.user-data" = module.configuration.user_data[each.key]
     "security.privileged"  = var.privileged
+    "security.nesting"     = var.privileged
   }
 
   device {


### PR DESCRIPTION
This fix an issue when running Magic Castle in privileged containers with Ubuntu or Debian where App Armor is running, for example in GitHub action VMs.