### PR TITLE
Split `privileged` and `nesting` variables for the incus module

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1152,10 +1152,13 @@ This setting can be enabled on at most one cluster per incus host.
 **default value**: true
 
 By default, the LXC containers created by Magic Castle are privileged. It is possible for security reasons
-to turn this off by provider `privileged = false` to the Incus module. However, due to kernel restrictions
+to turn this off by provider `privileged = false` to the Incus module. However, due to kernel restrictions
 designed to prevent unprivileged users from performing privileged operations like initiating mounts,
 the following features have to be disabled when running with `privileged = false`:
 - NFS server and mounts (`profile::nfs`)
+
+Also make sure that the line `root:1000000:1000000000` exists in both
+`/etc/subuid` and `/etc/subgid` when running with `privileged = false`.
 
 **Post build modification effect**: rebuild of all instances at next `terraform apply`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1159,6 +1159,16 @@ the following features have to be disabled when running with `privileged = false
 
 **Post build modification effect**: rebuild of all instances at next `terraform apply`.
 
+### nesting (optional)
+
+**default value**: true
+
+By default, the LXC containers created by Magic Castle have nesting enabled. 
+This allows containers to run workloads that require features such as docker or systemd inside the container.
+It is possible, for security or isolation reasons, to disable this by setting `nesting = false` in the Incus module. 
+
+**Post build modification effect**: rebuild of all instances at next `terraform apply`.
+
 ### shared_filesystems (optional)
 
 **default value**: `[]`

--- a/incus/incus.tf
+++ b/incus/incus.tf
@@ -13,6 +13,11 @@ variable "privileged" {
   default     = true
 }
 
+variable "nesting" {
+  description = "When using container, set the config security.nesting to this value"
+  default     = true
+}
+
 variable "shared_filesystems" {
   description = "Name of filesystems that need to be created and mounted in every instance"
   default     = []

--- a/incus/infrastructure.tf
+++ b/incus/infrastructure.tf
@@ -93,7 +93,7 @@ resource "incus_instance" "instances" {
   config = {
     "cloud-init.user-data" = module.configuration.user_data[each.key]
     "security.privileged"  = var.privileged
-    "security.nesting"     = var.privileged
+    "security.nesting"     = var.nesting
   }
 
   device {


### PR DESCRIPTION
This PR splits `security.nesting` and `security.privileged` settings for incus, allowing unprivileged containers to run nested containers