### PR TITLE
Provide ability to launch the image preparation process without manual intervention

### DIFF
--- a/common/configuration/puppet.yaml.tftpl
+++ b/common/configuration/puppet.yaml.tftpl
@@ -150,7 +150,7 @@ runcmd:
   - /opt/puppetlabs/bin/puppet config set report true
   - /opt/puppetlabs/bin/puppet config set postrun_command /opt/puppetlabs/bin/postrun
 %{ if contains(tags, "image") }
-  - /opt/puppetlabs/bin/puppet config set environment image
+  - /opt/puppetlabs/bin/puppet config --section agent set environment image
   - /opt/puppetlabs/bin/puppet config set postrun_command /usr/sbin/prepare4image.sh
 %{ endif }
   - systemctl enable puppet

--- a/common/configuration/puppet.yaml.tftpl
+++ b/common/configuration/puppet.yaml.tftpl
@@ -111,6 +111,7 @@ runcmd:
   - rm -rf /etc/puppetlabs/code/environments/production
   - git clone ${puppetenv_git} /etc/puppetlabs/code/environments/main
   - ln -s /etc/puppetlabs/code/environments/main /etc/puppetlabs/code/environments/production
+  - ln -s /etc/puppetlabs/code/environments/main /etc/puppetlabs/code/environments/image
   - |
     (
     cd /etc/puppetlabs/code/environments/production
@@ -148,6 +149,10 @@ runcmd:
   - /opt/puppetlabs/bin/puppet config set waitforcert 15s
   - /opt/puppetlabs/bin/puppet config set report true
   - /opt/puppetlabs/bin/puppet config set postrun_command /opt/puppetlabs/bin/postrun
+%{ if contains(tags, "image") }
+  - /opt/puppetlabs/bin/puppet config set environment image
+  - /opt/puppetlabs/bin/puppet config set postrun_command /usr/sbin/prepare4image.sh
+%{ endif }
   - systemctl enable puppet
 # Remove all ifcfg configuration files that have no corresponding network interface in ip link show.
   - for i in /etc/sysconfig/network-scripts/ifcfg-*; do if ! ip link show | grep -q "$${i##*-}:"; then rm -f $i; fi; done

--- a/common/configuration/puppet.yaml.tftpl
+++ b/common/configuration/puppet.yaml.tftpl
@@ -139,7 +139,7 @@ runcmd:
   - ${jsonencode(["/opt/puppetlabs/bin/puppet", "config", "set", conf.key, conf.value, "--section", conf.section])}
 %{ endfor ~}
 %{ if contains(tags, "image") }
-  - /opt/puppetlabs/bin/puppet config set environment image
+  - /opt/puppetlabs/bin/puppet config --section agent set environment image
   - /opt/puppetlabs/bin/puppet config set postrun_command /usr/sbin/prepare4image.sh
 %{ endif }
   - systemctl enable puppet

--- a/common/configuration/puppet.yaml.tftpl
+++ b/common/configuration/puppet.yaml.tftpl
@@ -111,6 +111,7 @@ runcmd:
   - rm -rf /etc/puppetlabs/code/environments/production
   - git clone ${puppetenv_git} /etc/puppetlabs/code/environments/main
   - ln -s /etc/puppetlabs/code/environments/main /etc/puppetlabs/code/environments/production
+  - ln -s /etc/puppetlabs/code/environments/main /etc/puppetlabs/code/environments/image
   - |
     (
     cd /etc/puppetlabs/code/environments/production
@@ -137,6 +138,10 @@ runcmd:
 %{ for conf in puppet_conf ~}
   - ${jsonencode(["/opt/puppetlabs/bin/puppet", "config", "set", conf.key, conf.value, "--section", conf.section])}
 %{ endfor ~}
+%{ if contains(tags, "image") }
+  - /opt/puppetlabs/bin/puppet config set environment image
+  - /opt/puppetlabs/bin/puppet config set postrun_command /usr/sbin/prepare4image.sh
+%{ endif }
   - systemctl enable puppet
 # Remove all ifcfg configuration files that have no corresponding network interface in ip link show.
   - for i in /etc/sysconfig/network-scripts/ifcfg-*; do if ! ip link show | grep -q "$${i##*-}:"; then rm -f $i; fi; done


### PR DESCRIPTION
Combined to https://github.com/ComputeCanada/puppet-magic_castle/pull/517, when an instance is assigned the tag `image`, Puppet is assigned to run `prepare4image.sh` as a postrun_script, therefore requiring zero human intervention to prepare the instance to be snapshotted.
