### PR TITLE
Update vhosts of gcloud and txt

### DIFF
--- a/dns/gcloud/variables.tf
+++ b/dns/gcloud/variables.tf
@@ -13,7 +13,7 @@ variable "domain" {
 variable "vhosts" {
   description = "List of vhost dns records to create as vhost.name.domain_name."
   type        = list(string)
-  default     = ["ipa", "jupyter", "mokey", "explore"]
+  default     = ["*"]
 }
 
 variable "domain_tag" {

--- a/dns/txt/variables.tf
+++ b/dns/txt/variables.tf
@@ -19,7 +19,7 @@ variable "vhost_tag" {
 variable "vhosts" {
   description = "List of vhost records A to create."
   type        = list(string)
-  default     = ["ipa", "jupyter", "mokey", "explore"]
+  default     = ["*"]
 }
 
 variable "dkim_public_key" {


### PR DESCRIPTION
Reflect past changes made to cloudflare: using wildcard instead of listing explictly the subdomains.

Closes #426