### PR TITLE
Add configurable Puppet agent settings

### DIFF
--- a/aws/infrastructure.tf
+++ b/aws/infrastructure.tf
@@ -32,6 +32,7 @@ module "configuration" {
   cloud_provider  = local.cloud_provider
   cloud_region    = local.cloud_region
   skip_upgrade    = var.skip_upgrade
+  puppet_conf     = var.puppet_conf
 }
 
 module "provision" {

--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -32,6 +32,7 @@ module "configuration" {
   cloud_provider  = local.cloud_provider
   cloud_region    = local.cloud_region
   skip_upgrade    = var.skip_upgrade
+  puppet_conf     = var.puppet_conf
 }
 
 module "provision" {

--- a/common/configuration/main.tf
+++ b/common/configuration/main.tf
@@ -9,6 +9,7 @@ locals {
 
 variable "config_git_url" {}
 variable "config_version" {}
+variable "puppet_conf" {}
 
 variable "sudoer_username" {}
 
@@ -92,6 +93,20 @@ locals {
     software_stack = var.software_stack,
   })
 
+  puppetservers = {
+    for host, values in var.inventory : host => try(values.local_ip, "") if contains(values.tags, "puppet")
+  }
+  puppet_conf = concat(
+    length(local.puppetservers) > 0 ? [
+      { key = "server", value = keys(local.puppetservers)[0], section = "main" }
+    ] : [],
+    [
+      { key = "waitforcert", value = "15s", section = "main" },
+      { key = "report", value = "true", section = "main" },
+      { key = "postrun_command", value = "/opt/puppetlabs/bin/postrun", section = "main" }
+    ],
+  )
+
   user_data = {
     for key, values in var.inventory : key =>
     templatefile("${path.module}/puppet.yaml.tftpl",
@@ -105,8 +120,9 @@ locals {
         domain_name           = var.domain_name
         puppetenv_git         = var.config_git_url,
         puppetenv_rev         = var.config_version,
-        puppetservers         = { for host, values in var.inventory : host => try(values.local_ip, "") if contains(values.tags, "puppet") }
+        puppetservers         = local.puppetservers
         puppetserver_password = local.puppet_passwd,
+        puppet_conf           = concat(local.puppet_conf, var.puppet_conf, [{ key = "certname", value = key, section = "main" }])
         sudoer_username       = var.sudoer_username,
         ssh_authorized_keys   = local.public_keys
         tf_ssh_public_key     = chomp(tls_private_key.ssh.public_key_openssh)

--- a/common/configuration/puppet.yaml.tftpl
+++ b/common/configuration/puppet.yaml.tftpl
@@ -134,13 +134,9 @@ runcmd:
 %{ endif ~}
   - chgrp puppet /etc/puppetlabs/puppet/csr_attributes.yaml
 %{ endif ~}
-%{ if length(puppetservers) > 0 ~}
-  - /opt/puppetlabs/bin/puppet config set server ${keys(puppetservers)[0]}
-%{ endif ~}
-  - /opt/puppetlabs/bin/puppet config set certname ${node_name}
-  - /opt/puppetlabs/bin/puppet config set waitforcert 15s
-  - /opt/puppetlabs/bin/puppet config set report true
-  - /opt/puppetlabs/bin/puppet config set postrun_command /opt/puppetlabs/bin/postrun
+%{ for conf in puppet_conf ~}
+  - ${jsonencode(["/opt/puppetlabs/bin/puppet", "config", "set", conf.key, conf.value, "--section", conf.section])}
+%{ endfor ~}
   - systemctl enable puppet
 # Remove all ifcfg configuration files that have no corresponding network interface in ip link show.
   - for i in /etc/sysconfig/network-scripts/ifcfg-*; do if ! ip link show | grep -q "$${i##*-}:"; then rm -f $i; fi; done

--- a/common/variables.tf
+++ b/common/variables.tf
@@ -179,3 +179,13 @@ variable "bastion_tags" {
   default     = []
   description = "Tags identifying instances that can be used by Terraform as the first hop to transfer files to the Puppet server."
 }
+
+variable "puppet_conf" {
+  type = list(object({
+    key     = string
+    value   = string
+    section = optional(string, "main")
+  }))
+  default     = []
+  description = "List of additional settings for Puppet agent https://help.puppet.com/core/current/Content/PuppetCore/Markdown/configuration.htm"
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -982,6 +982,32 @@ to transfer files to the Puppet server. By default, this list is inferred from t
 `terraform apply`. Providing an explicit list of tags allows bypassing the firewall rule inference,
 which can be useful when the agent is in the same network as the cluster.
 
+### 4.23 puppet_conf (optional)
+
+**default_value** = `[]`
+
+Defines additional Puppet agent settings to write to `/etc/puppetlabs/puppet/puppet.conf`
+on each instance during cloud-init. Each entry is an object with the following attributes:
+
+- `key`: Puppet setting name.
+- `value`: Puppet setting value.
+- `section`: Puppet configuration section. Defaults to `"main"` when omitted.
+
+Example:
+
+```hcl
+puppet_conf = [
+  { key = "runinterval", value = "15m" },
+  { key = "log_level", value = "notice", section = "agent" }
+]
+```
+
+For more information on available settings, refer to the
+[Puppet configuration reference](https://help.puppet.com/core/current/Content/PuppetCore/Markdown/configuration.htm).
+
+**Post build modification effect**: none. To change Puppet agent settings on existing
+instances, edit `/etc/puppetlabs/puppet/puppet.conf` manually or rebuild the instances.
+
 ## 5. Cloud Specific Configuration
 
 ### 5.1 Amazon Web Services

--- a/gcp/infrastructure.tf
+++ b/gcp/infrastructure.tf
@@ -32,6 +32,7 @@ module "configuration" {
   cloud_provider  = local.cloud_provider
   cloud_region    = local.cloud_region
   skip_upgrade    = var.skip_upgrade
+  puppet_conf     = var.puppet_conf
 }
 
 module "provision" {

--- a/incus/infrastructure.tf
+++ b/incus/infrastructure.tf
@@ -28,6 +28,7 @@ module "configuration" {
   cloud_provider  = "incus"
   cloud_region    = "local"
   skip_upgrade    = var.skip_upgrade
+  puppet_conf     = var.puppet_conf
 }
 
 module "provision" {

--- a/openstack/infrastructure.tf
+++ b/openstack/infrastructure.tf
@@ -27,6 +27,7 @@ module "configuration" {
   cloud_provider  = local.cloud_provider
   cloud_region    = local.cloud_region
   skip_upgrade    = var.skip_upgrade
+  puppet_conf     = var.puppet_conf
 }
 
 module "provision" {


### PR DESCRIPTION
Adds a `puppet_conf` variable to let users define additional Puppet agent settings during cloud-init.

- Adds top-level `puppet_conf` variable with `key`, `value`, and optional `section`.
- Passes `puppet_conf` through each provider module to `common/configuration`.
- Replaces hard-coded Puppet agent config commands with generated `puppet config set` commands.
- Keeps existing defaults for `waitforcert`, `report`, `postrun_command`, and per-node `certname`.
- Documents `puppet_conf` in `docs/README.md`.

Coauthored with gpt-5.5.