### PR TITLE
Support package upgrade scenarios

### DIFF
--- a/aws/infrastructure.tf
+++ b/aws/infrastructure.tf
@@ -31,7 +31,7 @@ module "configuration" {
   software_stack  = var.software_stack
   cloud_provider  = local.cloud_provider
   cloud_region    = local.cloud_region
-  skip_upgrade    = var.skip_upgrade
+  upgrade         = var.upgrade
   puppet_conf     = var.puppet_conf
 }
 

--- a/aws/infrastructure.tf
+++ b/aws/infrastructure.tf
@@ -14,6 +14,7 @@ module "design" {
   volumes        = var.volumes
   firewall_rules = var.firewall_rules
   bastion_tags   = var.bastion_tags
+  upgrade        = var.upgrade
 }
 
 module "configuration" {
@@ -31,7 +32,6 @@ module "configuration" {
   software_stack  = var.software_stack
   cloud_provider  = local.cloud_provider
   cloud_region    = local.cloud_region
-  upgrade         = var.upgrade
   puppet_conf     = var.puppet_conf
 }
 
@@ -215,6 +215,7 @@ locals {
       local_ip  = aws_network_interface.nic[x].private_ip
       prefix    = values.prefix
       tags      = values.tags
+      upgrade   = values.upgrade
       specs = merge({
         cpus = data.aws_ec2_instance_type.instance_type[values.prefix].default_vcpus
         ram  = data.aws_ec2_instance_type.instance_type[values.prefix].memory_size

--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -31,7 +31,7 @@ module "configuration" {
   software_stack  = var.software_stack
   cloud_provider  = local.cloud_provider
   cloud_region    = local.cloud_region
-  skip_upgrade    = var.skip_upgrade
+  upgrade         = var.upgrade
   puppet_conf     = var.puppet_conf
 }
 

--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -14,6 +14,7 @@ module "design" {
   volumes        = var.volumes
   firewall_rules = var.firewall_rules
   bastion_tags   = var.bastion_tags
+  upgrade        = var.upgrade
 }
 
 module "configuration" {
@@ -31,7 +32,6 @@ module "configuration" {
   software_stack  = var.software_stack
   cloud_provider  = local.cloud_provider
   cloud_region    = local.cloud_region
-  upgrade         = var.upgrade
   puppet_conf     = var.puppet_conf
 }
 
@@ -172,6 +172,7 @@ locals {
       local_ip  = azurerm_network_interface.nic[x].private_ip_address
       prefix    = values.prefix
       tags      = values.tags
+      upgrade   = values.upgrade
       specs = merge({
         cpus = local.vmsizes[values.type].vcpus
         ram  = local.vmsizes[values.type].ram

--- a/common/configuration/main.tf
+++ b/common/configuration/main.tf
@@ -23,7 +23,6 @@ variable "guest_passwd" {}
 
 variable "public_keys" {}
 
-variable "upgrade" {}
 variable "bastion_tags" {}
 
 resource "tls_private_key" "ssh" {
@@ -127,7 +126,7 @@ locals {
         ssh_authorized_keys   = local.public_keys
         tf_ssh_public_key     = chomp(tls_private_key.ssh.public_key_openssh)
         terraform_facts       = local.terraform_facts
-        upgrade               = var.upgrade
+        upgrade               = values.upgrade
         module_path           = path.module
         user_tf_required      = contains(values.tags, "puppet") || length(setintersection(values.tags, var.bastion_tags)) > 0
         hostkeys = {

--- a/common/configuration/main.tf
+++ b/common/configuration/main.tf
@@ -23,7 +23,7 @@ variable "guest_passwd" {}
 
 variable "public_keys" {}
 
-variable "skip_upgrade" {}
+variable "upgrade" {}
 variable "bastion_tags" {}
 
 resource "tls_private_key" "ssh" {
@@ -127,7 +127,7 @@ locals {
         ssh_authorized_keys   = local.public_keys
         tf_ssh_public_key     = chomp(tls_private_key.ssh.public_key_openssh)
         terraform_facts       = local.terraform_facts
-        skip_upgrade          = var.skip_upgrade
+        upgrade               = var.upgrade
         module_path           = path.module
         user_tf_required      = contains(values.tags, "puppet") || length(setintersection(values.tags, var.bastion_tags)) > 0
         hostkeys = {

--- a/common/configuration/puppet.yaml.tftpl
+++ b/common/configuration/puppet.yaml.tftpl
@@ -57,7 +57,7 @@ runcmd:
       echo -e "Include /etc/ssh/sshd_config.d/50-authenticationmethods.conf" >> /etc/ssh/sshd_config
       sed -i '/HostKey \/etc\/ssh\/ssh_host_ecdsa_key/ s/^#*/#/' /etc/ssh/sshd_config
       chmod 644 /etc/ssh/ssh_host_*_key.pub
-      chgrp ssh_keys /etc/ssh/ssh_host_*_key.pub
+      getent group ssh_keys && chgrp ssh_keys /etc/ssh/ssh_host_*_key.pub
       systemctl restart sshd
       # Install required packages in runcmd instead of packages to speedup configuration
       # of the admin user. This reduces the risk of Terraform timing out when trying to

--- a/common/configuration/puppet.yaml.tftpl
+++ b/common/configuration/puppet.yaml.tftpl
@@ -64,6 +64,8 @@ runcmd:
       # upload the terraform_data.yaml
       dnf -y install git pciutils unzip
       dnf -y remove cockpit\* firewalld --exclude=iptables
+      # dhcpcd is a dependency of cloud-init but it is not used
+      rpm -e --nodeps dhcpcd
 %{ if ! skip_upgrade ~}
       # Upgrade all packages except openvox if already installed
       dnf -y upgrade -x openvox*

--- a/common/configuration/puppet.yaml.tftpl
+++ b/common/configuration/puppet.yaml.tftpl
@@ -76,7 +76,7 @@ runcmd:
       install -m 700 /dev/null /opt/puppetlabs/bin/postrun
       # kernel configuration
 %{ if cloud_provider != "incus" ~}
-      systemctl disable kdump
+      test -f /usr/lib/systemd/system/kdump.service && systemctl disable kdump
       grubby --update-kernel=ALL --args="rd.driver.blacklist=nouveau nouveau.modeset=0 crashkernel=0M initcall_blacklist=algif_aead_init"
       grub2-mkconfig -o /boot/grub2/grub.cfg
 %{ endif ~}

--- a/common/configuration/puppet.yaml.tftpl
+++ b/common/configuration/puppet.yaml.tftpl
@@ -64,12 +64,12 @@ runcmd:
       # upload the terraform_data.yaml
       dnf -y install git pciutils unzip
       dnf -y remove cockpit\* firewalld --exclude=iptables
-      # dhcpcd is a dependency of cloud-init but it is not used
-      rpm -e --nodeps dhcpcd
 %{ if ! skip_upgrade ~}
       # Upgrade all packages except openvox if already installed
       dnf -y upgrade -x openvox*
 %{ endif ~}
+      # dhcpcd is a dependency of cloud-init but it is not used
+      rpm -e --nodeps dhcpcd
       # Puppet agent configuration and install
       dnf -y install https://yum.voxpupuli.org/openvox8-release-el-$(grep -oP 'VERSION_ID="\K\d*' /etc/os-release).noarch.rpm
       dnf -y install openvox-agent-8.23.1

--- a/common/configuration/puppet.yaml.tftpl
+++ b/common/configuration/puppet.yaml.tftpl
@@ -64,10 +64,13 @@ runcmd:
       # upload the terraform_data.yaml
       dnf -y install git pciutils unzip
       dnf -y remove cockpit\* firewalld --exclude=iptables
-%{ if ! skip_upgrade ~}
-      # Upgrade all packages except openvox if already installed
-      dnf -y upgrade -x openvox*
-%{ endif ~}
+    fi
+    # Upgrade all packages except openvox if already installed
+%{ if upgrade != "none" ~}
+  - %{ if startswith(upgrade, "vanilla") }test -f /etc/magic-castle-release || %{ endif }dnf -y upgrade -x openvox* %{ if strcontains(upgrade, "security") }--security%{ endif }
+%{ endif }
+  - |
+    if ! test -f /etc/magic-castle-release; then
       # dhcpcd is a dependency of cloud-init but it is not used
       rpm -e --nodeps dhcpcd
       # Puppet agent configuration and install
@@ -150,7 +153,7 @@ runcmd:
 %{ endif ~}
   # If the current image has already been configured with Magic Castle Puppet environment,
   # we can start puppet and skip reboot, reducing the delay for bringing the node up.
-  - test -f /etc/magic-castle-release && systemctl start puppet || true
+  - dnf needs-restarting -r && test -f /etc/magic-castle-release && systemctl start puppet || true
   - test -f /run/cloud-init-failed && echo 'WARNING - some steps cloud-init runcmd failed, listed in /run/cloud-init-failed. Manual fixing and rebooting required. ' | tee /etc/motd || true
 
 write_files:
@@ -243,7 +246,7 @@ output: { all: "| tee -a /var/log/cloud-init-output.log" }
 power_state:
   delay: now
   mode: reboot
-  condition: test ! -f /etc/magic-castle-release && test ! -f /run/cloud-init-failed
+  condition: "! dnf needs-restarting -r || (test ! -f /etc/magic-castle-release && test ! -f /run/cloud-init-failed)"
 
 # Configure owner of /var/log/cloud-init.log
 syslog_fix_perms: root:systemd-journal

--- a/common/configuration/puppet.yaml.tftpl
+++ b/common/configuration/puppet.yaml.tftpl
@@ -249,7 +249,7 @@ output: { all: "| tee -a /var/log/cloud-init-output.log" }
 power_state:
   delay: now
   mode: reboot
-  condition: "! dnf needs-restarting -r || (test ! -f /etc/magic-castle-release && test ! -f /run/cloud-init-failed)"
+  condition: "test ! -f /run/cloud-init-failed && (! dnf needs-restarting -r || test ! -f /etc/magic-castle-release)"
 
 # Configure owner of /var/log/cloud-init.log
 syslog_fix_perms: root:systemd-journal

--- a/common/configuration/puppet.yaml.tftpl
+++ b/common/configuration/puppet.yaml.tftpl
@@ -77,12 +77,6 @@ runcmd:
       dnf -y install https://yum.voxpupuli.org/openvox8-release-el-$(grep -oP 'VERSION_ID="\K\d*' /etc/os-release).noarch.rpm
       dnf -y install openvox-agent-8.23.1
       install -m 700 /dev/null /opt/puppetlabs/bin/postrun
-      # kernel configuration
-%{ if cloud_provider != "incus" ~}
-      test -f /usr/lib/systemd/system/kdump.service && systemctl disable kdump
-      grubby --update-kernel=ALL --args="rd.driver.blacklist=nouveau nouveau.modeset=0 crashkernel=0M initcall_blacklist=algif_aead_init"
-      grub2-mkconfig -o /boot/grub2/grub.cfg
-%{ endif ~}
 %{ if cloud_provider == "gcp" ~}
       # Google Cloud user-data fact generates a warning because its size is greater than what is allowed (<4096 bytes).
       # We have no use for it, so we remove startup-script, user-data and user-data-encoding when running in GCE.
@@ -91,6 +85,15 @@ runcmd:
       sed -i "/gce_data\['instance'\] = instance_data/i \ \ \ \ \ \ \ \ \ \ instance_data['attributes'].delete('user-data-encoding')" /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter/resolvers/gce.rb
 %{ endif ~}
     fi
+%{ if cloud_provider != "incus" ~}
+  # Kernel configuration
+  - |
+    if ! test -f /etc/magic-castle-release || ! dnf needs-restarting -r; then
+      test -f /usr/lib/systemd/system/kdump.service && systemctl disable kdump
+      grubby --update-kernel=ALL --args="rd.driver.blacklist=nouveau nouveau.modeset=0 crashkernel=0M initcall_blacklist=algif_aead_init"
+      grub2-mkconfig -o /boot/grub2/grub.cfg
+    fi
+%{ endif ~}
 %{ if contains(tags, "puppet") ~}
 # Install puppetserver
   - dnf -y install openvox-server-8.11.0

--- a/common/design/main.tf
+++ b/common/design/main.tf
@@ -15,11 +15,12 @@ locals {
         for i in range(lookup(attrs, "count", 1)) : {
           (format("%s%d", prefix, i + 1)) = merge(
             { image = var.image },
+            { upgrade = var.upgrade },
             { disk_size = max(var.min_disk_size, [for tag in attrs.tags : lookup(local.min_disk_size_per_tags, tag, 0)]...) },
             { for attr, value in attrs : attr => value if !contains(["count"], attr) },
             {
               prefix = prefix,
-              specs  = { for attr, value in attrs : attr => value if !contains(["count", "tags", "image"], attr) }
+              specs  = { for attr, value in attrs : attr => value if !contains(["count", "tags", "image", "upgrade"], attr) }
             },
           )
         }

--- a/common/design/variables.tf
+++ b/common/design/variables.tf
@@ -7,3 +7,4 @@ variable "firewall_rules" {}
 variable "min_disk_size" {}
 variable "image" {}
 variable "bastion_tags" {}
+variable "upgrade" {}

--- a/common/variables.tf
+++ b/common/variables.tf
@@ -150,10 +150,14 @@ variable "pool" {
   default = []
 }
 
-variable "skip_upgrade" {
-  type        = bool
-  default     = false
-  description = "If set to true, the packages already installed in the base image will not be upgraded on first boot."
+variable "upgrade" {
+  type        = string
+  default     = "vanilla-all"
+  description = "If set to all, all base packages are upgraded on first boot. When prefixed with `vanilla-`, upgrade only happen with vanilla based image."
+  validation {
+    condition     = contains(["all", "none", "security", "vanilla-all", "vanilla-security"], var.upgrade)
+    error_message = "Upgrade options are: all, none, security, vanilla-all, vanilla-security"
+  }
 }
 
 variable "puppetfile" {

--- a/common/variables.tf
+++ b/common/variables.tf
@@ -31,6 +31,10 @@ variable "instances" {
     condition     = length(var.instances) == 0 || sum([for key, values in var.instances : contains(values["tags"], "login") ? 1 : 0]) < 2
     error_message = "At most one type of instances in var.instances can have the _login_ tag"
   }
+  validation {
+    condition     = alltrue(flatten([for key, values in var.instances : contains(["all", "none", "security", "vanilla-all", "vanilla-security"], lookup(values, "upgrade", "vanilla-all"))]))
+    error_message = "At least one instance's `upgrade` is invalid. Valid values are: all, none, security, vanilla-all, vanilla-security."
+  }
 }
 
 variable "image" {

--- a/docs/README.md
+++ b/docs/README.md
@@ -572,13 +572,14 @@ recommended minimum size per tag as specified in the following table.
     ```
     features = ["skylake", "nvidia"]
     ```
+8. `upgrade`: specification of the package upgrade behavior to use for this instance type (default: global [`upgrade`](#420-upgrade-optional) value, whose default is `"vanilla-all"`).
 
 The instance specifications are retrieved from the cloud provider data source, but it is possible to explicitly specify them.
 
-7. `cpus`: number of logical processors on the node - [`CPUs` in slurm.conf](https://slurm.schedmd.com/slurm.conf.html#OPT_CPUs)
-8. `ram`: size of real memory on the node in megabyte - [`RealMemory` in slurm.conf](https://slurm.schedmd.com/slurm.conf.html#OPT_RealMemory)
-9. `gpus`: number of graphics processors on the node - [`Gres=gpu:<gpus>` in slurm.conf](https://slurm.schedmd.com/slurm.conf.html#OPT_Gres_1)
-10. `gpu_type`: type of graphics processor on the node - [`Gres=gpu:<gpu_type>:<gpus>` in slurm.conf](https://slurm.schedmd.com/slurm.conf.html#OPT_Gres_1)
+9. `cpus`: number of logical processors on the node - [`CPUs` in slurm.conf](https://slurm.schedmd.com/slurm.conf.html#OPT_CPUs)
+10. `ram`: size of real memory on the node in megabyte - [`RealMemory` in slurm.conf](https://slurm.schedmd.com/slurm.conf.html#OPT_RealMemory)
+11. `gpus`: number of graphics processors on the node - [`Gres=gpu:<gpus>` in slurm.conf](https://slurm.schedmd.com/slurm.conf.html#OPT_Gres_1)
+12. `gpu_type`: type of graphics processor on the node - [`Gres=gpu:<gpu_type>:<gpus>` in slurm.conf](https://slurm.schedmd.com/slurm.conf.html#OPT_Gres_1)
 
 For some cloud providers, it is possible to define additional attributes.
 The following sections present the available attributes per provider.

--- a/docs/README.md
+++ b/docs/README.md
@@ -951,16 +951,21 @@ managed by the workload scheduler through Terraform API. For more information, r
 will be instantiated, others will stay uninstantiated or will be destroyed
 if previously instantiated.
 
-### 4.20 skip_upgrade (optional)
+### 4.20 upgrade (optional)
 
-**default_value** = `false`
+**default_value** = `"vanilla-all"`
 
-If true, the base image packages will not be upgraded during the first boot. By default,
-all packages are upgraded.
+Defines if base image packages are upgraded during the first boot. Possible values are:
+
+- `"all"`: upgrade all packages
+- `"none"`: do not upgrade packages
+- `"security"`: upgrade security packages only
+- `"vanilla-all"`: upgrade all packages only when booting from a vanilla base image
+- `"vanilla-security"`: upgrade security packages only when booting from a vanilla base image
 
 **Post build modification effect**: No effect on currently built instances. Ones created
 after the modification will take into consideration the new value of the parameter to determine
-whether they should upgrade the base image packages or not.
+how they should upgrade the base image packages.
 
 ### 4.21 puppetfile (optional)
 

--- a/gcp/infrastructure.tf
+++ b/gcp/infrastructure.tf
@@ -31,7 +31,7 @@ module "configuration" {
   software_stack  = var.software_stack
   cloud_provider  = local.cloud_provider
   cloud_region    = local.cloud_region
-  skip_upgrade    = var.skip_upgrade
+  upgrade         = var.upgrade
   puppet_conf     = var.puppet_conf
 }
 

--- a/gcp/infrastructure.tf
+++ b/gcp/infrastructure.tf
@@ -14,6 +14,7 @@ module "design" {
   volumes        = var.volumes
   firewall_rules = var.firewall_rules
   bastion_tags   = var.bastion_tags
+  upgrade        = var.upgrade
 }
 
 module "configuration" {
@@ -31,7 +32,6 @@ module "configuration" {
   software_stack  = var.software_stack
   cloud_provider  = local.cloud_provider
   cloud_region    = local.cloud_region
-  upgrade         = var.upgrade
   puppet_conf     = var.puppet_conf
 }
 
@@ -178,6 +178,7 @@ locals {
       local_ip  = google_compute_address.nic[x].address
       prefix    = values.prefix
       tags      = values.tags
+      upgrade   = values.upgrade
       specs = merge({
         cpus = data.external.machine_type[values["prefix"]].result["vcpus"]
         ram  = data.external.machine_type[values["prefix"]].result["ram"]

--- a/incus/infrastructure.tf
+++ b/incus/infrastructure.tf
@@ -9,6 +9,7 @@ module "design" {
   volumes        = var.volumes
   firewall_rules = var.firewall_rules
   bastion_tags   = var.bastion_tags
+  upgrade        = var.upgrade
 }
 
 module "configuration" {
@@ -27,7 +28,6 @@ module "configuration" {
   software_stack  = var.software_stack
   cloud_provider  = "incus"
   cloud_region    = "local"
-  upgrade         = var.upgrade
   puppet_conf     = var.puppet_conf
 }
 
@@ -154,6 +154,7 @@ locals {
     host => {
       prefix  = values.prefix
       tags    = values.tags
+      upgrade = values.upgrade
       specs   = values.specs
       volumes = {}
     }

--- a/incus/infrastructure.tf
+++ b/incus/infrastructure.tf
@@ -27,7 +27,7 @@ module "configuration" {
   software_stack  = var.software_stack
   cloud_provider  = "incus"
   cloud_region    = "local"
-  skip_upgrade    = var.skip_upgrade
+  upgrade         = var.upgrade
   puppet_conf     = var.puppet_conf
 }
 

--- a/openstack/infrastructure.tf
+++ b/openstack/infrastructure.tf
@@ -26,7 +26,7 @@ module "configuration" {
   software_stack  = var.software_stack
   cloud_provider  = local.cloud_provider
   cloud_region    = local.cloud_region
-  skip_upgrade    = var.skip_upgrade
+  upgrade         = var.upgrade
   puppet_conf     = var.puppet_conf
 }
 

--- a/openstack/infrastructure.tf
+++ b/openstack/infrastructure.tf
@@ -9,6 +9,7 @@ module "design" {
   volumes        = var.volumes
   firewall_rules = var.firewall_rules
   bastion_tags   = var.bastion_tags
+  upgrade        = var.upgrade
 }
 
 module "configuration" {
@@ -26,7 +27,6 @@ module "configuration" {
   software_stack  = var.software_stack
   cloud_provider  = local.cloud_provider
   cloud_region    = local.cloud_region
-  upgrade         = var.upgrade
   puppet_conf     = var.puppet_conf
 }
 
@@ -136,6 +136,7 @@ locals {
       local_ip  = openstack_networking_port_v2.nic[x].all_fixed_ips[0]
       prefix    = values.prefix
       tags      = values.tags
+      upgrade   = values.upgrade
       specs = merge({
         cpus = data.openstack_compute_flavor_v2.flavors[values.type].vcpus
         ram  = data.openstack_compute_flavor_v2.flavors[values.type].ram


### PR DESCRIPTION
Rename `skip_upgrade` to `upgrade` and add support for three more scenarios:
- `upgrade = "security"`: always upgrade to security related upgrades
- `upgrade = "vanilla-security"`upgrade packages only if the image is vanilla
- `upgrade = "all"`: upgrade packages during cloud-init, always

The previous scenarios still supported are:
- `upgrade = "vanilla-all"` limit package upgrade to security related upgrades only if the image is vanilla - equivalent of previous `skip_upgrade = false` 
- `upgrade = "none"`, never upgrade, equivalent of `skip_upgrade = true` 

