### PR TITLE
Replace postrun command for image tag

### DIFF
--- a/common/configuration/puppet.yaml.tftpl
+++ b/common/configuration/puppet.yaml.tftpl
@@ -148,7 +148,7 @@ runcmd:
 %{ endfor ~}
 %{ if contains(tags, "image") }
   - /opt/puppetlabs/bin/puppet config --section agent set environment image
-  - /opt/puppetlabs/bin/puppet config set postrun_command /usr/sbin/prepare4image.sh
+  - /opt/puppetlabs/bin/puppet config set postrun_command "systemd-run --unit=prepare4image --collect --no-block /usr/sbin/prepare4image.sh"
 %{ endif }
   - systemctl enable puppet
 # Remove all ifcfg configuration files that have no corresponding network interface in ip link show.


### PR DESCRIPTION
The command is replaced by a call to systemd-run to make sure the puppet run is completed and the report is available once prepare4image.sh starts. Otherwise, we could not know if the run was successful.